### PR TITLE
Change from static mutexes to instance variables to prevent over-locking

### DIFF
--- a/include/iomanager/Receiver.hpp
+++ b/include/iomanager/Receiver.hpp
@@ -248,8 +248,7 @@ private:
   typename std::enable_if<dunedaq::serialization::is_serializable<MessageType>::value, MessageType>::type read_network(
     Receiver::timeout_t const& timeout)
   {
-      static std::mutex receive_mutex;
-      std::lock_guard<std::mutex> lk(receive_mutex);
+      std::lock_guard<std::mutex> lk(m_receive_mutex);
 
     if (m_network_subscriber_ptr != nullptr) {
       auto response = m_network_subscriber_ptr->receive(timeout);
@@ -284,6 +283,7 @@ private:
   std::shared_ptr<ipm::Receiver> m_network_receiver_ptr{ nullptr };
   std::shared_ptr<ipm::Subscriber> m_network_subscriber_ptr{ nullptr };
   std::mutex m_callback_mutex;
+  std::mutex m_receive_mutex;
 };
 
 } // namespace iomanager

--- a/include/iomanager/Sender.hpp
+++ b/include/iomanager/Sender.hpp
@@ -139,8 +139,7 @@ private:
 
     auto serialized = dunedaq::serialization::serialize(message, dunedaq::serialization::kMsgPack);
     // TLOG() << "Serialized message for network sending: " << serialized.size() << ", this=" << (void*)this;
-    static std::mutex mt_send_mutex;
-    std::lock_guard<std::mutex> lk(mt_send_mutex);
+    std::lock_guard<std::mutex> lk(m_send_mutex);
 
     m_network_sender_ptr->send(serialized.data(), serialized.size(), timeout, topic);
   }
@@ -155,6 +154,7 @@ private:
   ConnectionId m_conn_id;
   ConnectionRef m_conn_ref;
   std::shared_ptr<ipm::Sender> m_network_sender_ptr;
+  std::mutex m_send_mutex;
 };
 
 } // namespace iomanager


### PR DESCRIPTION
when there are multiple connections of the same data type.