### PR TITLE
Make ref_to_id public

### DIFF
--- a/include/iomanager/IOManager.hpp
+++ b/include/iomanager/IOManager.hpp
@@ -191,10 +191,7 @@ public:
     receiver->remove_callback();
   }
 
-private:
-  IOManager() {}
-
-  ConnectionId ref_to_id(ConnectionRef const& ref)
+  const ConnectionId ref_to_id(ConnectionRef const& ref) const
   {
     for (auto& conn : m_connections) {
       if (conn.uid == ref.uid)
@@ -215,6 +212,10 @@ private:
 
     throw ConnectionNotFound(ERS_HERE, ref.uid);
   }
+
+private:
+  IOManager() {}
+
 
   using SenderMap = std::map<ConnectionRef, std::shared_ptr<Sender>>;
   using ReceiverMap = std::map<ConnectionRef, std::shared_ptr<Receiver>>;

--- a/include/iomanager/Receiver.hpp
+++ b/include/iomanager/Receiver.hpp
@@ -45,10 +45,19 @@ public:
   static constexpr timeout_t s_block = timeout_t::max();
   static constexpr timeout_t s_no_block = timeout_t::zero();
 
-  explicit Receiver(std::string const& name)
-    : utilities::NamedObject(name)
+  explicit Receiver(ConnectionId conn_id, ConnectionRef conn_ref)
+    : utilities::NamedObject(conn_ref.name)
+      , m_conn_id(conn_id)
+      , m_conn_ref(conn_ref)
   {}
   virtual ~Receiver() = default;
+
+  ConnectionId const conn_id() const { return m_conn_id; }
+  ConnectionRef const conn_ref() const { return m_conn_ref; }
+
+protected:
+    ConnectionId m_conn_id;
+    ConnectionRef m_conn_ref;
 };
 
 // Interface
@@ -56,8 +65,8 @@ template<typename Datatype>
 class ReceiverConcept : public Receiver
 {
 public:
-  explicit ReceiverConcept(std::string const& name)
-    : Receiver(name)
+  explicit ReceiverConcept(ConnectionId conn_id, ConnectionRef conn_ref)
+    : Receiver(conn_id, conn_ref)
   {}
   virtual Datatype receive(Receiver::timeout_t timeout) = 0;
   virtual void add_callback(std::function<void(Datatype&)> callback) = 0;
@@ -70,9 +79,7 @@ class QueueReceiverModel : public ReceiverConcept<Datatype>
 {
 public:
   explicit QueueReceiverModel(ConnectionId conn_id, ConnectionRef conn_ref)
-    : ReceiverConcept<Datatype>(conn_ref.name)
-    , m_conn_id(conn_id)
-    , m_conn_ref(conn_ref)
+    : ReceiverConcept<Datatype>(conn_id, conn_ref)
   {
     TLOG() << "QueueReceiverModel created with DT! Addr: " << this;
     // get queue ref from queueregistry based on conn_id
@@ -83,9 +90,7 @@ public:
   }
 
   QueueReceiverModel(QueueReceiverModel&& other)
-    : ReceiverConcept<Datatype>(other.get_name())
-    , m_conn_id(other.m_conn_id)
-    , m_conn_ref(other.m_conn_ref)
+    : ReceiverConcept<Datatype>(other.m_conn_id, other.m_conn_ref)
     , m_with_callback(other.m_with_callback.load())
     , m_callback(std::move(other.m_callback))
     , m_event_loop_runner(std::move(other.m_event_loop_runner))
@@ -98,17 +103,17 @@ public:
   {
     if (m_with_callback) {
       TLOG() << "QueueReceiver model is equipped with callback! Ignoring receive call.";
-      throw ReceiveCallbackConflict(ERS_HERE, m_conn_id.uid);
+      throw ReceiveCallbackConflict(ERS_HERE, this->conn_id().uid);
     }
     if (m_queue == nullptr) {
-      throw ConnectionInstanceNotFound(ERS_HERE, m_conn_id.uid);
+      throw ConnectionInstanceNotFound(ERS_HERE, this->conn_id().uid);
     }
     // TLOG() << "Hand off data...";
     Datatype dt;
     try {
       m_queue->pop(dt, timeout);
     } catch (QueueTimeoutExpired& ex) {
-      throw TimeoutExpired(ERS_HERE, m_conn_id.uid, "pop", timeout.count(), ex);
+      throw TimeoutExpired(ERS_HERE, this->conn_id().uid, "pop", timeout.count(), ex);
     }
     return dt;
     // if (m_queue->write(
@@ -147,8 +152,6 @@ public:
   }
 
 private:
-  ConnectionId m_conn_id;
-  ConnectionRef m_conn_ref;
   std::atomic<bool> m_with_callback{ false };
   std::function<void(Datatype&)> m_callback;
   std::unique_ptr<std::thread> m_event_loop_runner;
@@ -161,13 +164,11 @@ class NetworkReceiverModel : public ReceiverConcept<Datatype>
 {
 public:
   explicit NetworkReceiverModel(ConnectionId conn_id, ConnectionRef conn_ref, bool ref_to_topic = false)
-    : ReceiverConcept<Datatype>(conn_ref.name)
-    , m_conn_id(conn_id)
-    , m_conn_ref(conn_ref)
+    : ReceiverConcept<Datatype>(conn_id, conn_ref)
   {
     TLOG() << "NetworkReceiverModel created with DT! ID: " << (ref_to_topic ? conn_ref.uid : conn_id.uid) << " Addr: " << static_cast<void*>(this);
     // get network resources
-    if (m_conn_id.service_type == ServiceType::kNetReceiver) {
+    if (conn_id.service_type == ServiceType::kNetReceiver) {
 
       try {
         m_network_receiver_ptr =
@@ -191,8 +192,7 @@ public:
   ~NetworkReceiverModel() { remove_callback(); }
 
   NetworkReceiverModel(NetworkReceiverModel&& other)
-    : ReceiverConcept<Datatype>(other.get_name())
-    , m_conn_id(other.m_conn_id)
+    : ReceiverConcept<Datatype>(other.m_conn_id, other.m_conn_ref)
     , m_with_callback(other.m_with_callback.load())
     , m_callback(std::move(other.m_callback))
     , m_event_loop_runner(std::move(other.m_event_loop_runner))
@@ -205,7 +205,7 @@ public:
     try {
       return read_network<Datatype>(timeout);
     } catch (ipm::ReceiveTimeoutExpired& ex) {
-      throw TimeoutExpired(ERS_HERE, m_conn_ref.uid, "receive", timeout.count(), ex);
+      throw TimeoutExpired(ERS_HERE, this->conn_ref().uid, "receive", timeout.count(), ex);
     }
   }
 
@@ -244,7 +244,7 @@ private:
       }
     }
 
-    throw TimeoutExpired(ERS_HERE, m_conn_id.uid, "network receive", timeout.count());
+    throw TimeoutExpired(ERS_HERE, this->conn_id().uid, "network receive", timeout.count());
     return MessageType();
   }
 
@@ -287,8 +287,6 @@ private:
     throw NetworkMessageNotSerializable(ERS_HERE, typeid(MessageType).name());
   }
 
-  ConnectionId m_conn_id;
-  ConnectionRef m_conn_ref;
   std::atomic<bool> m_with_callback{ false };
   std::function<void(Datatype&)> m_callback;
   std::unique_ptr<std::thread> m_event_loop_runner;

--- a/include/iomanager/Sender.hpp
+++ b/include/iomanager/Sender.hpp
@@ -35,10 +35,19 @@ public:
   static constexpr timeout_t s_block = timeout_t::max();
   static constexpr timeout_t s_no_block = timeout_t::zero();
 
-  explicit Sender(std::string const& name)
-    : utilities::NamedObject(name)
+  explicit Sender(ConnectionId conn_id, ConnectionRef conn_ref)
+    : utilities::NamedObject(conn_ref.name)
+      , m_conn_id(conn_id)
+      , m_conn_ref(conn_ref)
   {}
   virtual ~Sender() = default;
+
+  ConnectionId const conn_id() const { return m_conn_id; }
+  ConnectionRef const conn_ref() const { return m_conn_ref; }
+
+protected:
+  ConnectionId m_conn_id;
+  ConnectionRef m_conn_ref;
 };
 
 // Interface
@@ -46,8 +55,8 @@ template<typename Datatype>
 class SenderConcept : public Sender
 {
 public:
-  explicit SenderConcept(std::string const& name)
-    : Sender(name)
+  explicit SenderConcept(ConnectionId conn_id, ConnectionRef conn_ref)
+    : Sender(conn_id, conn_ref)
   {}
   virtual void send(Datatype&& data, Sender::timeout_t timeout, Topic_t topic = "") = 0;
 };
@@ -58,9 +67,7 @@ class QueueSenderModel : public SenderConcept<Datatype>
 {
 public:
   explicit QueueSenderModel(ConnectionId conn_id, ConnectionRef conn_ref)
-    : SenderConcept<Datatype>(conn_ref.name)
-    , m_conn_id(conn_id)
-    , m_conn_ref(conn_ref)
+    : SenderConcept<Datatype>(conn_id, conn_ref)
   {
     TLOG() << "QueueSenderModel created with DT! Addr: " << static_cast<void*>(this);
     m_queue = QueueRegistry::get().get_queue<Datatype>(conn_id.uid);
@@ -69,9 +76,7 @@ public:
   }
 
   QueueSenderModel(QueueSenderModel&& other)
-    : SenderConcept<Datatype>(other.get_name())
-    , m_conn_id(other.m_conn_id)
-    , m_conn_ref(other.m_conn_ref)
+    : SenderConcept<Datatype>(other.m_conn_id, other.m_conn_ref)
     , m_queue(other.m_queue)
   {}
 
@@ -82,18 +87,16 @@ public:
     }
 
     if (m_queue == nullptr)
-      throw ConnectionInstanceNotFound(ERS_HERE, m_conn_id.uid);
+      throw ConnectionInstanceNotFound(ERS_HERE, this->conn_id().uid);
 
     try {
       m_queue->push(std::move(data), timeout);
     } catch (QueueTimeoutExpired& ex) {
-      throw TimeoutExpired(ERS_HERE, m_conn_id.uid, "push", timeout.count(), ex);
+      throw TimeoutExpired(ERS_HERE, this->conn_id().uid, "push", timeout.count(), ex);
     }
   }
 
 private:
-  ConnectionId m_conn_id;
-  ConnectionRef m_conn_ref;
   std::shared_ptr<Queue<Datatype>> m_queue;
 };
 
@@ -105,9 +108,7 @@ public:
   using SenderConcept<Datatype>::send;
 
   explicit NetworkSenderModel(ConnectionId conn_id, ConnectionRef conn_ref)
-    : SenderConcept<Datatype>(conn_ref.name)
-    , m_conn_id(conn_id)
-    , m_conn_ref(conn_ref)
+    : SenderConcept<Datatype>(conn_id, conn_ref)
   {
     TLOG() << "NetworkSenderModel created with DT! Addr: " << static_cast<void*>(this);
     // get network resources
@@ -115,9 +116,7 @@ public:
   }
 
   NetworkSenderModel(NetworkSenderModel&& other)
-    : SenderConcept<Datatype>(other.get_name())
-    , m_conn_id(other.m_conn_id)
-    , m_conn_ref(other.m_conn_ref)
+    : SenderConcept<Datatype>(other.m_conn_id, other.m_conn_ref)
     , m_network_sender_ptr(other.m_network_sender_ptr)
   {}
 
@@ -126,7 +125,7 @@ public:
     try {
       write_network<Datatype>(data, timeout, topic);
     } catch (ipm::SendTimeoutExpired& ex) {
-      throw TimeoutExpired(ERS_HERE, m_conn_id.uid, "send", timeout.count(), ex);
+      throw TimeoutExpired(ERS_HERE, this->conn_id().uid, "send", timeout.count(), ex);
     }
   }
 
@@ -136,7 +135,7 @@ private:
   write_network(MessageType& message, Sender::timeout_t const& timeout, std::string const& topic = "")
   {
     if (m_network_sender_ptr == nullptr)
-      throw ConnectionInstanceNotFound(ERS_HERE, m_conn_id.uid);
+      throw ConnectionInstanceNotFound(ERS_HERE, this->conn_id().uid);
 
     auto serialized = dunedaq::serialization::serialize(message, dunedaq::serialization::kMsgPack);
     // TLOG() << "Serialized message for network sending: " << serialized.size() << ", this=" << (void*)this;
@@ -152,8 +151,6 @@ private:
     throw NetworkMessageNotSerializable(ERS_HERE, typeid(MessageType).name());
   }
 
-  ConnectionId m_conn_id;
-  ConnectionRef m_conn_ref;
   std::shared_ptr<ipm::Sender> m_network_sender_ptr;
   std::mutex m_send_mutex;
 };


### PR DESCRIPTION
Resolves #11 

Note that additional changes will be needed in `daqconf` to get the functionality desired (i.e. filling in the Datatype field).