### PR TITLE
Don't emit error when receive() gets nothing: this is OK

### DIFF
--- a/include/iomanager/FollyQueue.hpp
+++ b/include/iomanager/FollyQueue.hpp
@@ -54,8 +54,6 @@ public:
   bool pop_noexcept(value_t& val, const duration_t& dur) override
   {
       if (!m_queue.try_dequeue_for(val, dur)) {
-          ers::error( QueueTimeoutExpired(
-              ERS_HERE, this->get_name(), "pop", std::chrono::duration_cast<std::chrono::milliseconds>(dur).count()));
           return false;
       }
       return true;

--- a/include/iomanager/Receiver.hpp
+++ b/include/iomanager/Receiver.hpp
@@ -301,7 +301,6 @@ private:
           return std::make_optional<MessageType>(dunedaq::serialization::deserialize<MessageType>(res.data));
       }
   
-      ers::error( TimeoutExpired(ERS_HERE, m_conn_id.uid, "network receive", timeout.count()) );
       return std::nullopt;
   }
 


### PR DESCRIPTION
It's common for receive() to not get anything, so it's not an error condition