### PR TITLE
Add configuration parameter to control how often ConfigClient

### DIFF
--- a/include/iomanager/IOManager.hpp
+++ b/include/iomanager/IOManager.hpp
@@ -54,7 +54,7 @@ public:
   IOManager(IOManager&&) = delete;                 ///< IOManager is not move-constructible
   IOManager& operator=(IOManager&&) = delete;      ///< IOManager is not move-assignable
 
-  void configure(Queues_t queues, Connections_t connections, bool use_config_client = true)
+  void configure(Queues_t queues, Connections_t connections, bool use_config_client, std::chrono::milliseconds config_client_interval)
   {
     Queues_t qCfg = queues;
     Connections_t nwCfg;
@@ -64,7 +64,7 @@ public:
     }
 
     QueueRegistry::get().configure(qCfg);
-    NetworkManager::get().configure(nwCfg, use_config_client);
+    NetworkManager::get().configure(nwCfg, use_config_client, config_client_interval);
   }
 
   void reset()

--- a/include/iomanager/network/ConfigClient.hpp
+++ b/include/iomanager/network/ConfigClient.hpp
@@ -40,8 +40,9 @@ public:
    *
    * @param server  Name/address of the connection server to publish to
    * @param port    Port on the connection server to connect to
+   * @param publish_interval  Time to wait between connection republish (keep-alive)
    */
-  ConfigClient(const std::string& server, const std::string& port);
+  ConfigClient(const std::string& server, const std::string& port, std::chrono::milliseconds publish_interval);
 
   /**
    * Destructor: stops the publishing hread and retracts all published

--- a/include/iomanager/network/NetworkManager.hpp
+++ b/include/iomanager/network/NetworkManager.hpp
@@ -42,7 +42,7 @@ public:
   ~NetworkManager() { reset(); }
 
   void gather_stats(opmonlib::InfoCollector& ci, int /*level*/);
-  void configure(const Connections_t& connections, bool use_config_client = true);
+  void configure(const Connections_t& connections, bool use_config_client, std::chrono::milliseconds config_client_interval);
   void reset();
 
   std::shared_ptr<ipm::Receiver> get_receiver(ConnectionId const& conn_id);
@@ -77,6 +77,7 @@ private:
   std::atomic<bool> m_subscriber_update_thread_running{ false };
 
   std::unique_ptr<ConfigClient> m_config_client;
+  std::chrono::milliseconds m_config_client_interval;
 
   mutable std::mutex m_receiver_plugin_map_mutex;
   mutable std::mutex m_sender_plugin_map_mutex;

--- a/src/network/ConfigClient.cpp
+++ b/src/network/ConfigClient.cpp
@@ -36,11 +36,12 @@ ConfigClient::ConfigClient(const std::string& server, const std::string& port, s
   tcp::resolver resolver(m_ioContext);
   m_addr = resolver.resolve(server, port);
   m_active = true;
-  m_thread = std::thread([this,&publish_interval]() {
+  m_thread = std::thread([this,publish_interval]() {
     while (m_active) {
       try {
         publish();
         m_connected = true;
+        TLOG_DEBUG(24) << "Automatic publish complete";
       } catch (ers::Issue& ex) {
         if (m_connected)
           ers::error(ex);

--- a/src/network/ConfigClient.cpp
+++ b/src/network/ConfigClient.cpp
@@ -24,7 +24,7 @@ using nlohmann::json;
 
 using namespace dunedaq::iomanager;
 
-ConfigClient::ConfigClient(const std::string& server, const std::string& port)
+ConfigClient::ConfigClient(const std::string& server, const std::string& port, std::chrono::milliseconds publish_interval)
 {
   char* part = getenv("DUNEDAQ_PARTITION");
   if (part) {
@@ -36,7 +36,7 @@ ConfigClient::ConfigClient(const std::string& server, const std::string& port)
   tcp::resolver resolver(m_ioContext);
   m_addr = resolver.resolve(server, port);
   m_active = true;
-  m_thread = std::thread([this]() {
+  m_thread = std::thread([this,&publish_interval]() {
     while (m_active) {
       try {
         publish();
@@ -53,7 +53,7 @@ ConfigClient::ConfigClient(const std::string& server, const std::string& port)
         else
           TLOG() << ers_ex;
       }
-      std::this_thread::sleep_for(1s);
+      std::this_thread::sleep_for(publish_interval);
     }
     retract();
     if (!m_connected) {

--- a/src/network/NetworkManager.cpp
+++ b/src/network/NetworkManager.cpp
@@ -50,7 +50,7 @@ NetworkManager::gather_stats(opmonlib::InfoCollector& ci, int level)
 }
 
 void
-NetworkManager::configure(const Connections_t& connections, bool use_config_client)
+NetworkManager::configure(const Connections_t& connections, bool use_config_client, std::chrono::milliseconds config_client_interval)
 {
   if (!m_preconfigured_connections.empty()) {
     throw AlreadyConfigured(ERS_HERE);
@@ -80,7 +80,8 @@ NetworkManager::configure(const Connections_t& connections, bool use_config_clie
     if (env) {
       connectionPort = std::string(env);
     }
-    m_config_client = std::make_unique<ConfigClient>(connectionServer, connectionPort);
+    m_config_client = std::make_unique<ConfigClient>(connectionServer, connectionPort, config_client_interval);
+    m_config_client_interval = config_client_interval;
   }
 }
 
@@ -303,7 +304,7 @@ NetworkManager::update_subscribers()
         }
       }
     }
-    std::this_thread::sleep_for(std::chrono::milliseconds(500));
+    std::this_thread::sleep_for(m_config_client_interval);
   }
 }
 

--- a/test/apps/config_client_test.cxx
+++ b/test/apps/config_client_test.cxx
@@ -60,11 +60,11 @@ main(int argc, char* argv[])
 
   std::string part="DUNEDAQ_PARTITION="+name;
   try {
-    ConfigClient dummyclient(server, port);
+    ConfigClient dummyclient(server, port, 1000ms);
   } catch (EnvNotFound& ex) {
     putenv(const_cast<char*>(part.c_str())); // NOLINT
   }
-  ConfigClient client(server, port);
+  ConfigClient client(server, port, 1000ms);
 
   std::vector<ConnectionRegistration> connections;
   std::ostringstream numStr;

--- a/unittest/IOManager_test.cxx
+++ b/unittest/IOManager_test.cxx
@@ -197,7 +197,7 @@ struct ConfigurationTestFixture
     connections.emplace_back(Connection{ pub1_id, "inproc://bar", ConnectionType::kPubSub });
     connections.emplace_back(Connection{ pub2_id, "inproc://baz", ConnectionType::kPubSub });
     connections.emplace_back(Connection{ pub3_id, "inproc://qui", ConnectionType::kPubSub });
-    IOManager::get()->configure(queues, connections);
+    IOManager::get()->configure(queues, connections, false, 0ms); // Not using connectivity service
   }
   ~ConfigurationTestFixture() { IOManager::get()->reset(); }
 

--- a/unittest/NetworkManager_test.cxx
+++ b/unittest/NetworkManager_test.cxx
@@ -59,7 +59,7 @@ struct NetworkManagerTestFixture
     testConn.id = pubSubConnId3;
     testConn.uri = "inproc://abr";
     testConfig.push_back(testConn);
-    NetworkManager::get().configure(testConfig, false); // Not using ConfigClient
+    NetworkManager::get().configure(testConfig, false, 0ms); // Not using ConfigClient
   }
   ~NetworkManagerTestFixture() { NetworkManager::get().reset(); }
 
@@ -140,11 +140,11 @@ BOOST_FIXTURE_TEST_CASE(FakeConfigure, NetworkManagerTestFixture)
   testConn.connection_type = ConnectionType::kSendRecv;
   testConfig.push_back(testConn);
   BOOST_REQUIRE_EXCEPTION(
-    NetworkManager::get().configure(testConfig), AlreadyConfigured, [&](AlreadyConfigured const&) { return true; });
+    NetworkManager::get().configure(testConfig, false, 0ms), AlreadyConfigured, [&](AlreadyConfigured const&) { return true; });
 
   NetworkManager::get().reset();
 
-  NetworkManager::get().configure(testConfig, false);
+  NetworkManager::get().configure(testConfig, false, 0ms);
   conn_res = NetworkManager::get().get_preconfigured_connections(id_notfound);
   BOOST_REQUIRE_EQUAL(conn_res.connections.size(), 1);
   conn_res = NetworkManager::get().get_preconfigured_connections(sendRecvConnId);
@@ -158,7 +158,7 @@ BOOST_FIXTURE_TEST_CASE(NameCollisionInConfiguration, NetworkManagerTestFixture)
   testConfig.emplace_back(Connection{ sendRecvConnId, "inproc://foo", ConnectionType::kSendRecv });
   testConfig.emplace_back(Connection{ sendRecvConnId, "inproc://bar", ConnectionType::kSendRecv });
   BOOST_REQUIRE_EXCEPTION(
-    NetworkManager::get().configure(testConfig), NameCollision, [&](NameCollision const&) { return true; });
+    NetworkManager::get().configure(testConfig, false, 0ms), NameCollision, [&](NameCollision const&) { return true; });
 }
 
 BOOST_AUTO_TEST_CASE(MakeIPMPlugins) {}

--- a/unittest/performance_test.cxx
+++ b/unittest/performance_test.cxx
@@ -55,7 +55,7 @@ struct ConfigurationTestFixture
 
     dunedaq::iomanager::Connections_t connections;
     connections.emplace_back(Connection{ network_id, "inproc://foo", ConnectionType::kSendRecv });
-    IOManager::get()->configure(queues, connections);
+    IOManager::get()->configure(queues, connections, false, 0ms); // Not using connectivity service
   }
   ~ConfigurationTestFixture() { IOManager::get()->reset(); }
 


### PR DESCRIPTION
re-publishes information to Connectivity Service (and how often NetworkManager checks for new publishers). Remove default arguments from configure methods (found a couple places where defaults were being incorrectly used). Update tests as appropriate.