### PR TITLE
Provide an alternative cross-session connection API, removing the

### DIFF
--- a/include/iomanager/CommonIssues.hpp
+++ b/include/iomanager/CommonIssues.hpp
@@ -29,6 +29,8 @@ ERS_DECLARE_ISSUE(iomanager,      // namespace
 
 ERS_DECLARE_ISSUE(iomanager, OperationFailed, message, ((std::string)message))
 
+ERS_DECLARE_ISSUE(iomanager, EnvNotFound, "Environment variable " << name << " not found", ((std::string)name))
+
 ERS_DECLARE_ISSUE(iomanager,
                   DatatypeMismatch,
                   "Declared datatype in ConnectionId for connection " << cuid << " is " << cid_dt

--- a/include/iomanager/Receiver.hpp
+++ b/include/iomanager/Receiver.hpp
@@ -27,18 +27,21 @@ public:
   static constexpr timeout_t s_block = timeout_t::max();
   static constexpr timeout_t s_no_block = timeout_t::zero();
 
-  explicit Receiver(ConnectionId const& this_conn)
+  explicit Receiver(ConnectionId const& this_conn, std::string const& session)
     : utilities::NamedObject(this_conn.uid)
     , m_conn(this_conn)
+      , m_session(session)
   {
   }
 
   virtual ~Receiver() = default;
 
   ConnectionId id() const { return m_conn; }
+  std::string session() const { return m_session; }
 
 protected:
   ConnectionId m_conn;
+  std::string m_session;
 };
 
 // Interface
@@ -46,8 +49,8 @@ template<typename Datatype>
 class ReceiverConcept : public Receiver
 {
 public:
-  explicit ReceiverConcept(ConnectionId const& conn_id)
-    : Receiver(conn_id)
+  explicit ReceiverConcept(ConnectionId const& conn_id, std::string const& session)
+    : Receiver(conn_id, session)
   {
   }
   virtual Datatype receive(Receiver::timeout_t timeout) = 0;

--- a/include/iomanager/Sender.hpp
+++ b/include/iomanager/Sender.hpp
@@ -25,17 +25,20 @@ public:
   static constexpr timeout_t s_block = timeout_t::max();
   static constexpr timeout_t s_no_block = timeout_t::zero();
 
-  explicit Sender(ConnectionId const& this_conn)
+  explicit Sender(ConnectionId const& this_conn, std::string const& session)
     : utilities::NamedObject(this_conn.uid)
     , m_conn(this_conn)
+      , m_session(session)
   {
   }
   virtual ~Sender() = default;
 
   ConnectionId id() const { return m_conn; }
+  std::string session() const { return m_session; }
 
 protected:
   ConnectionId m_conn;
+  std::string m_session;
 };
 
 // Interface
@@ -43,8 +46,8 @@ template<typename Datatype>
 class SenderConcept : public Sender
 {
 public:
-  explicit SenderConcept(ConnectionId const& conn_id)
-    : Sender(conn_id)
+  explicit SenderConcept(ConnectionId const& conn_id, std::string const& session)
+    : Sender(conn_id, session)
   {}
   virtual void send(Datatype&& data, Sender::timeout_t timeout) = 0;     // NOLINT
   virtual bool try_send(Datatype&& data, Sender::timeout_t timeout) = 0; // NOLINT

--- a/include/iomanager/network/NetworkIssues.hpp
+++ b/include/iomanager/network/NetworkIssues.hpp
@@ -28,8 +28,6 @@ ERS_DECLARE_ISSUE(iomanager, NameCollision, "Multiple instances of name " << nam
 
 ERS_DECLARE_ISSUE(iomanager, AlreadyConfigured, "The NetworkManager has already been configured", )
 
-ERS_DECLARE_ISSUE(iomanager, EnvNotFound, "Environment variable " << name << " not found", ((std::string)name))
-
 ERS_DECLARE_ISSUE(iomanager, FailedPublish, "Failed to publish configuration " << result, ((std::string)result))
 
 ERS_DECLARE_ISSUE(iomanager,

--- a/include/iomanager/network/NetworkManager.hpp
+++ b/include/iomanager/network/NetworkManager.hpp
@@ -45,14 +45,14 @@ public:
   void configure(const Connections_t& connections, bool use_config_client, std::chrono::milliseconds config_client_interval);
   void reset();
 
-  std::shared_ptr<ipm::Receiver> get_receiver(ConnectionId const& conn_id);
-  std::shared_ptr<ipm::Sender> get_sender(ConnectionId const& conn_id);
+  std::shared_ptr<ipm::Receiver> get_receiver(ConnectionId const& conn_id, std::string const& session);
+  std::shared_ptr<ipm::Sender> get_sender(ConnectionId const& conn_id, std::string const& session);
 
   void remove_sender(ConnectionId const& conn_id);
 
-  bool is_pubsub_connection(ConnectionId const& conn_id) const;
+  bool is_pubsub_connection(ConnectionId const& conn_id, std::string const& session) const;
 
-  ConnectionResponse get_connections(ConnectionId const& conn_id, bool restrict_single = false) const;
+  ConnectionResponse get_connections(ConnectionId const& conn_id, std::string const& session, bool restrict_single = false) const;
   ConnectionResponse get_preconfigured_connections(ConnectionId const& conn_id) const;
 
   std::set<std::string> get_datatypes(std::string const& uid) const;
@@ -67,7 +67,7 @@ private:
   NetworkManager& operator=(NetworkManager const&) = delete;
   NetworkManager& operator=(NetworkManager&&) = delete;
 
-  std::shared_ptr<ipm::Receiver> create_receiver(std::vector<ConnectionInfo> connections, ConnectionId const& conn_id);
+  std::shared_ptr<ipm::Receiver> create_receiver(std::vector<ConnectionInfo> connections, ConnectionId const& conn_id, std::string const& session);
   std::shared_ptr<ipm::Sender> create_sender(ConnectionInfo connection);
 
   void update_subscribers();
@@ -76,7 +76,12 @@ private:
   std::unordered_map<ConnectionId, std::shared_ptr<ipm::Receiver>> m_receiver_plugins;
   std::unordered_map<ConnectionId, std::shared_ptr<ipm::Sender>> m_sender_plugins;
   
-  std::unordered_map<ConnectionId, std::shared_ptr<ipm::Subscriber>> m_subscriber_plugins;
+  struct SubscriberInfo {
+  std::shared_ptr<ipm::Subscriber> plugin;
+    ConnectionId id;
+  std::string session;
+  };
+  std::vector<SubscriberInfo> m_subscriber_plugins;
   std::unique_ptr<std::thread> m_subscriber_update_thread;
   std::atomic<bool> m_subscriber_update_thread_running{ false };
 

--- a/include/iomanager/network/NetworkReceiverModel.hpp
+++ b/include/iomanager/network/NetworkReceiverModel.hpp
@@ -35,8 +35,8 @@ template<typename Datatype>
 class NetworkReceiverModel : public ReceiverConcept<Datatype>
 {
 public:
-  explicit NetworkReceiverModel(ConnectionId const& conn_id)
-    : ReceiverConcept<Datatype>(conn_id)
+  explicit NetworkReceiverModel(ConnectionId const& conn_id, std::string const& session)
+    : ReceiverConcept<Datatype>(conn_id, session)
   {
     TLOG() << "NetworkReceiverModel created with DT! ID: " << conn_id.uid << " Addr: " << static_cast<void*>(this);
     try {
@@ -86,14 +86,14 @@ public:
 
   void subscribe(std::string topic) override
   {
-    if (NetworkManager::get().is_pubsub_connection(this->m_conn)) {
-        std::dynamic_pointer_cast<ipm::Subscriber>(m_network_receiver_ptr)->subscribe(topic);
+    if (NetworkManager::get().is_pubsub_connection(this->m_conn, this->session())) {
+      std::dynamic_pointer_cast<ipm::Subscriber>(m_network_receiver_ptr)->subscribe(topic);
     }
   }
   void unsubscribe(std::string topic) override
   {
-    if (NetworkManager::get().is_pubsub_connection(this->m_conn)) {
-        std::dynamic_pointer_cast<ipm::Subscriber>(m_network_receiver_ptr)->unsubscribe(topic);
+    if (NetworkManager::get().is_pubsub_connection(this->m_conn, this->session())) {
+      std::dynamic_pointer_cast<ipm::Subscriber>(m_network_receiver_ptr)->unsubscribe(topic);
     }
   }
 
@@ -106,7 +106,7 @@ private:
            std::chrono::duration_cast<Receiver::timeout_t>(std::chrono::steady_clock::now() - start) < timeout) {
 
       try {
-        m_network_receiver_ptr = NetworkManager::get().get_receiver(this->id());
+        m_network_receiver_ptr = NetworkManager::get().get_receiver(this->id(), this->session());
       } catch (ConnectionNotFound const& ex) {
         m_network_receiver_ptr = nullptr;
         std::this_thread::sleep_for(std::chrono::milliseconds(10));

--- a/include/iomanager/network/NetworkSenderModel.hpp
+++ b/include/iomanager/network/NetworkSenderModel.hpp
@@ -31,8 +31,8 @@ class NetworkSenderModel : public SenderConcept<Datatype>
 public:
   using SenderConcept<Datatype>::send;
 
-  explicit NetworkSenderModel(ConnectionId const& conn_id)
-    : SenderConcept<Datatype>(conn_id)
+  explicit NetworkSenderModel(ConnectionId const& conn_id, std::string const& session)
+    : SenderConcept<Datatype>(conn_id, session)
   {
     TLOG() << "NetworkSenderModel created with DT! Addr: " << static_cast<void*>(this);
     try {
@@ -80,9 +80,9 @@ private:
              std::chrono::duration_cast<Sender::timeout_t>(std::chrono::steady_clock::now() - start) <= timeout) {
       // get network resources
       try {
-        m_network_sender_ptr = NetworkManager::get().get_sender(this->id());
+        m_network_sender_ptr = NetworkManager::get().get_sender(this->id(), this->session());
 
-        if (NetworkManager::get().is_pubsub_connection(this->id())) {
+        if (NetworkManager::get().is_pubsub_connection(this->id(), this->session())) {
           TLOG() << "Setting topic to " << this->id().data_type;
           m_topic = this->id().data_type;
         }

--- a/include/iomanager/queue/QueueIssues.hpp
+++ b/include/iomanager/queue/QueueIssues.hpp
@@ -56,6 +56,12 @@ ERS_DECLARE_ISSUE(iomanager,
                   "QueueReceiverModel for uid " << conn_uid << " is equipped with callback! Ignoring receive call.",
                   ((std::string)conn_uid))
 
+ERS_DECLARE_ISSUE(iomanager,
+                  CrossSessionQueue,
+                  "This application is in session " << app_session << ", and cannot use a queue configured for session "
+                                                    << queue_session << "! Queue ID " << queue_id,
+                  ((std::string)app_session)((std::string)queue_session)((std::string)queue_id))
+
 // Re-enable coverage collection LCOV_EXCL_STOP
 
 } // namespace dunedaq

--- a/include/iomanager/queue/QueueReceiverModel.hpp
+++ b/include/iomanager/queue/QueueReceiverModel.hpp
@@ -31,8 +31,8 @@ template<typename Datatype>
 class QueueReceiverModel : public ReceiverConcept<Datatype>
 {
 public:
-  explicit QueueReceiverModel(ConnectionId const& request)
-    : ReceiverConcept<Datatype>(request)
+  explicit QueueReceiverModel(ConnectionId const& request, std::string const& session)
+    : ReceiverConcept<Datatype>(request, session)
   {
     TLOG() << "QueueReceiverModel created with DT! Addr: " << this;
     // get queue ref from queueregistry based on conn_id
@@ -40,6 +40,10 @@ public:
     // m_source = std::make_unique<appfwk::DAQSource<Datatype>>(sink_name);
     m_queue = QueueRegistry::get().get_queue<Datatype>(request.uid);
     TLOG() << "QueueReceiverModel m_queue=" << static_cast<void*>(m_queue.get());
+
+    if (session != "" && get_session() != session) {
+      throw CrossSessionQueue(ERS_HERE, get_session(), session, request.uid);
+    }
   }
 
   QueueReceiverModel(QueueReceiverModel&& other)

--- a/include/iomanager/queue/QueueSenderModel.hpp
+++ b/include/iomanager/queue/QueueSenderModel.hpp
@@ -27,13 +27,16 @@ template<typename Datatype>
 class QueueSenderModel : public SenderConcept<Datatype>
 {
 public:
-  explicit QueueSenderModel(ConnectionId const& request)
-    : SenderConcept<Datatype>(request)
+  explicit QueueSenderModel(ConnectionId const& request, std::string const& session)
+    : SenderConcept<Datatype>(request, session)
   {
     TLOG() << "QueueSenderModel created with DT! Addr: " << static_cast<void*>(this);
     m_queue = QueueRegistry::get().get_queue<Datatype>(request.uid);
     TLOG() << "QueueSenderModel m_queue=" << static_cast<void*>(m_queue.get());
-    // get queue ref from queueregistry based on conn_id
+
+    if (session != "" && get_session() != session) {
+      throw CrossSessionQueue(ERS_HERE, get_session(), session, request.uid);
+    }
   }
 
   QueueSenderModel(QueueSenderModel&& other)

--- a/schema/iomanager/connection.jsonnet
+++ b/schema/iomanager/connection.jsonnet
@@ -19,7 +19,6 @@ local c = {
     ConnectionId: s.record("ConnectionId",[
         s.field("uid", self.uid, doc="Identifier for the Connection instance"),
         s.field("data_type", self.datatype, doc="Name of the expected data type"),
-        s.field("session", self.uid, default="", doc="Name of the DAQ session this Connection lives in")
     ]),
 
     Queue: s.record("QueueConfig", [

--- a/unittest/NetworkManager_test.cxx
+++ b/unittest/NetworkManager_test.cxx
@@ -130,10 +130,10 @@ BOOST_FIXTURE_TEST_CASE(FakeConfigure, NetworkManagerTestFixture)
   conn_res = NetworkManager::get().get_preconfigured_connections(id_notfound);
   BOOST_REQUIRE_EQUAL(conn_res.connections.size(), 0);
 
-  BOOST_REQUIRE(!NetworkManager::get().is_pubsub_connection(sendRecvConnId));
-  BOOST_REQUIRE(NetworkManager::get().is_pubsub_connection(pubSubConnId1));
-  BOOST_REQUIRE(NetworkManager::get().is_pubsub_connection(topicConnId));
-  BOOST_REQUIRE_EXCEPTION(NetworkManager::get().is_pubsub_connection(id_notfound),
+  BOOST_REQUIRE(!NetworkManager::get().is_pubsub_connection(sendRecvConnId, get_session()));
+  BOOST_REQUIRE(NetworkManager::get().is_pubsub_connection(pubSubConnId1, get_session()));
+  BOOST_REQUIRE(NetworkManager::get().is_pubsub_connection(topicConnId, get_session()));
+  BOOST_REQUIRE_EXCEPTION(NetworkManager::get().is_pubsub_connection(id_notfound, get_session()),
                           ConnectionNotFound,
                           [](ConnectionNotFound const&) { return true; });
 


### PR DESCRIPTION
session from ConnectionID and instead taking it as an argument to get_sender/get_receiver.