### PR TITLE
suppress ttb/task.h deprecated warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,14 @@ daq_add_application(iomanager_stress_test     iomanager_stress_test.cxx  TEST LI
 daq_add_application(iomanager_stress_test_pubsub     iomanager_stress_test_pubsub.cxx  TEST LINK_LIBRARIES iomanager pthread )
 daq_add_application(reconnection_test     reconnection_test.cxx  TEST LINK_LIBRARIES iomanager pthread )
 
+# DPF-2023-Mar-17: No better way to replace tbb/task.h since Intel deprecated it.
+target_compile_options( iomanager_stress_test PRIVATE
+	$<$<OR:$<CXX_COMPILER_ID:GNU>,$<CXX_COMPILER_ID:Clang>>:-DTBB_SUPPRESS_DEPRECATED_MESSAGES=1>)
+target_compile_options( iomanager_stress_test_pubsub PRIVATE
+	$<$<OR:$<CXX_COMPILER_ID:GNU>,$<CXX_COMPILER_ID:Clang>>:-DTBB_SUPPRESS_DEPRECATED_MESSAGES=1>)
+target_compile_options( reconnection_test PRIVATE
+	$<$<OR:$<CXX_COMPILER_ID:GNU>,$<CXX_COMPILER_ID:Clang>>:-DTBB_SUPPRESS_DEPRECATED_MESSAGES=1>)
+
 daq_add_application( queues_vs_threads_folly          queues_vs_threads_folly.cxx          TEST LINK_LIBRARIES iomanager )
 daq_add_application( queues_vs_threads_folly_throwing queues_vs_threads_folly_throwing.cxx TEST LINK_LIBRARIES iomanager )
 daq_add_application( queues_vs_threads_iomanager      queues_vs_threads_iomanager.cxx      TEST LINK_LIBRARIES iomanager )


### PR DESCRIPTION
No better way to treat "tab/task.h" deprecated warnings. Suppressing it.

For reference, here is a public discussion about similar issues https://gcc.gnu.org/bugzilla/show_bug.cgi?id=101228