### PR TITLE
Added debug printout to show the server and port

### DIFF
--- a/src/network/ConfigClient.cpp
+++ b/src/network/ConfigClient.cpp
@@ -28,7 +28,6 @@ ConfigClient::ConfigClient(const std::string& server,
                            const std::string& port,
                            std::chrono::milliseconds publish_interval)
 {
-  TLOG_DEBUG(24) << "Server and Port are " << server << ":" << port;
   char* session = getenv("DUNEDAQ_SESSION");
   if (session) {
     m_session = std::string(session);

--- a/src/network/ConfigClient.cpp
+++ b/src/network/ConfigClient.cpp
@@ -28,6 +28,7 @@ ConfigClient::ConfigClient(const std::string& server,
                            const std::string& port,
                            std::chrono::milliseconds publish_interval)
 {
+  TLOG_DEBUG(24) << "Server and Port are " << server << ":" << port;
   char* session = getenv("DUNEDAQ_SESSION");
   if (session) {
     m_session = std::string(session);

--- a/src/network/NetworkManager.cpp
+++ b/src/network/NetworkManager.cpp
@@ -82,6 +82,7 @@ NetworkManager::configure(const Connections_t& connections,
     if (env) {
       connectionPort = std::string(env);
     }
+    TLOG_DEBUG(17) << "ConnectionServer host and port are " << connectionServer << ":" << connectionPort;
     m_config_client = std::make_unique<ConfigClient>(connectionServer, connectionPort, config_client_interval);
     m_config_client_interval = config_client_interval;
   }


### PR DESCRIPTION
I don't know if this information is available somewhere else, but I found it useful to know what ConnSvc host and port was being used in our Apps.  If the info is available elsewhere, we can close this PR.  And, I'm explicitly listing the Target Release as 4.1 since this isn't an urgent issue.