### PR TITLE
Move IOManager functionality to CPP source file where possible, hxx file

### DIFF
--- a/include/iomanager/detail/IOManager.hxx
+++ b/include/iomanager/detail/IOManager.hxx
@@ -1,0 +1,172 @@
+#include "iomanager/connection/Structs.hpp"
+#include "iomanager/network/ConfigClient.hpp"
+#include "iomanager/network/NetworkManager.hpp"
+#include "iomanager/network/NetworkReceiverModel.hpp"
+#include "iomanager/network/NetworkSenderModel.hpp"
+#include "iomanager/queue/QueueReceiverModel.hpp"
+#include "iomanager/queue/QueueRegistry.hpp"
+#include "iomanager/queue/QueueSenderModel.hpp"
+
+#include "nlohmann/json.hpp"
+
+#include <cstdlib>
+#include <map>
+#include <memory>
+#include <regex>
+#include <string>
+
+namespace dunedaq {
+
+namespace iomanager {
+
+using namespace connection;
+
+template<typename Datatype>
+inline void
+IOManager::add_callback(ConnectionId const& id, std::function<void(Datatype&)> callback)
+{
+  auto receiver = get_receiver<Datatype>(id);
+  receiver->add_callback(callback);
+}
+
+template<typename Datatype>
+inline std::shared_ptr<ReceiverConcept<Datatype>>
+IOManager::get_receiver(std::string const& uid)
+{
+  auto data_type = datatype_to_string<Datatype>();
+  ConnectionId id;
+  id.uid = uid;
+  id.data_type = data_type;
+  id.session = m_session;
+  return get_receiver<Datatype>(id);
+}
+
+template<typename Datatype>
+inline std::shared_ptr<ReceiverConcept<Datatype>>
+IOManager::get_receiver(ConnectionId id)
+{
+  if (id.data_type != datatype_to_string<Datatype>()) {
+    throw DatatypeMismatch(ERS_HERE, id.uid, id.data_type, datatype_to_string<Datatype>());
+  }
+
+  if (id.session == "") {
+    id.session = m_session;
+  }
+
+  static std::mutex dt_receiver_mutex;
+  std::lock_guard<std::mutex> lk(dt_receiver_mutex);
+
+  if (!m_receivers.count(id)) {
+    if (QueueRegistry::get().has_queue(id.uid, id.data_type)) { // if queue
+      TLOG() << "Creating QueueReceiverModel for uid " << id.uid << ", datatype " << id.data_type;
+      m_receivers[id] = std::make_shared<QueueReceiverModel<Datatype>>(id);
+    } else {
+      TLOG() << "Creating NetworkReceiverModel for uid " << id.uid << ", datatype " << id.data_type << " in session "
+             << id.session;
+      m_receivers[id] = std::make_shared<NetworkReceiverModel<Datatype>>(id);
+    }
+  }
+  return std::dynamic_pointer_cast<ReceiverConcept<Datatype>>(m_receivers[id]); // NOLINT
+}
+
+template<typename Datatype>
+inline std::shared_ptr<SenderConcept<Datatype>>
+IOManager::get_sender(std::string const& uid)
+{
+  auto data_type = datatype_to_string<Datatype>();
+  ConnectionId id;
+  id.uid = uid;
+  id.data_type = data_type;
+  id.session = m_session;
+  return get_sender<Datatype>(id);
+}
+
+template<typename Datatype>
+inline std::shared_ptr<SenderConcept<Datatype>>
+IOManager::get_sender(ConnectionId id)
+{
+  if (id.data_type != datatype_to_string<Datatype>()) {
+    throw DatatypeMismatch(ERS_HERE, id.uid, id.data_type, datatype_to_string<Datatype>());
+  }
+
+  if (id.session == "") {
+    id.session = m_session;
+  }
+
+  static std::mutex dt_sender_mutex;
+  std::lock_guard<std::mutex> lk(dt_sender_mutex);
+
+  if (!m_senders.count(id)) {
+    if (QueueRegistry::get().has_queue(id.uid, id.data_type)) { // if queue
+      TLOG() << "Creating QueueSenderModel for uid " << id.uid << ", datatype " << id.data_type;
+      m_senders[id] = std::make_shared<QueueSenderModel<Datatype>>(id);
+    } else {
+      TLOG() << "Creating NetworkSenderModel for uid " << id.uid << ", datatype " << id.data_type << " in session "
+             << id.session;
+      m_senders[id] = std::make_shared<NetworkSenderModel<Datatype>>(id);
+    }
+  }
+  return std::dynamic_pointer_cast<SenderConcept<Datatype>>(m_senders[id]);
+}
+
+template<typename Datatype>
+inline void
+IOManager::add_callback(std::string const& uid, std::function<void(Datatype&)> callback)
+{
+  auto receiver = get_receiver<Datatype>(uid);
+  receiver->add_callback(callback);
+}
+
+template<typename Datatype>
+inline void
+IOManager::remove_callback(ConnectionId const& id)
+{
+  auto receiver = get_receiver<Datatype>(id);
+  receiver->remove_callback();
+}
+
+template<typename Datatype>
+inline void
+IOManager::remove_callback(std::string const& uid)
+{
+  auto receiver = get_receiver<Datatype>(uid);
+  receiver->remove_callback();
+}
+
+} // namespace iomanager
+
+// Helper functions
+[[maybe_unused]] static std::shared_ptr<iomanager::IOManager> // NOLINT(build/namespaces)
+get_iomanager()
+{
+  return iomanager::IOManager::get();
+}
+
+template<typename Datatype>
+static std::shared_ptr<iomanager::SenderConcept<Datatype>> // NOLINT(build/namespaces)
+get_iom_sender(iomanager::ConnectionId const& id)
+{
+  return iomanager::IOManager::get()->get_sender<Datatype>(id);
+}
+
+template<typename Datatype>
+static std::shared_ptr<iomanager::ReceiverConcept<Datatype>> // NOLINT(build/namespaces)
+get_iom_receiver(iomanager::ConnectionId const& id)
+{
+  return iomanager::IOManager::get()->get_receiver<Datatype>(id);
+}
+
+template<typename Datatype>
+static std::shared_ptr<iomanager::SenderConcept<Datatype>> // NOLINT(build/namespaces)
+get_iom_sender(std::string const& uid)
+{
+  return iomanager::IOManager::get()->get_sender<Datatype>(uid);
+}
+
+template<typename Datatype>
+static std::shared_ptr<iomanager::ReceiverConcept<Datatype>> // NOLINT(build/namespaces)
+get_iom_receiver(std::string const& uid)
+{
+  return iomanager::IOManager::get()->get_receiver<Datatype>(uid);
+}
+} // namespace dunedaq

--- a/include/iomanager/network/NetworkReceiverModel.hpp
+++ b/include/iomanager/network/NetworkReceiverModel.hpp
@@ -10,21 +10,10 @@
 #define IOMANAGER_INCLUDE_IOMANAGER_NRECEIVER_HPP_
 
 #include "iomanager/Receiver.hpp"
-#include "iomanager/network/NetworkIssues.hpp"
-#include "iomanager/network/NetworkManager.hpp"
 
 #include "ipm/Subscriber.hpp"
-#include "logging/Logging.hpp"
 #include "serialization/Serialization.hpp"
-#include "utilities/ReusableThread.hpp"
 
-#include <atomic>
-#include <memory>
-#include <optional>
-#include <string>
-#include <thread>
-#include <typeinfo>
-#include <utility>
 
 namespace dunedaq {
 
@@ -35,35 +24,12 @@ template<typename Datatype>
 class NetworkReceiverModel : public ReceiverConcept<Datatype>
 {
 public:
-  explicit NetworkReceiverModel(ConnectionId const& conn_id)
-    : ReceiverConcept<Datatype>(conn_id)
-  {
-    TLOG() << "NetworkReceiverModel created with DT! ID: " << conn_id.uid << " Addr: " << static_cast<void*>(this);
-    try {
-      get_receiver(std::chrono::milliseconds(1000));
-    } catch (ConnectionNotFound const& ex) {
-      TLOG() << "Initial connection attempt failed: " << ex;
-    }
-  }
+  explicit NetworkReceiverModel(ConnectionId const& conn_id);
   ~NetworkReceiverModel() { remove_callback(); }
 
-  NetworkReceiverModel(NetworkReceiverModel&& other)
-    : ReceiverConcept<Datatype>(other.m_conn.uid)
-    , m_with_callback(other.m_with_callback.load())
-    , m_callback(std::move(other.m_callback))
-    , m_event_loop_runner(std::move(other.m_event_loop_runner))
-    , m_network_receiver_ptr(std::move(other.m_network_receiver_ptr))
-  {
-  }
+  NetworkReceiverModel(NetworkReceiverModel&& other);
 
-  Datatype receive(Receiver::timeout_t timeout) override
-  {
-    try {
-      return read_network<Datatype>(timeout);
-    } catch (ipm::ReceiveTimeoutExpired& ex) {
-      throw TimeoutExpired(ERS_HERE, this->id().uid, "receive", timeout.count(), ex);
-    }
-  }
+  Datatype receive(Receiver::timeout_t timeout) override;
 
   std::optional<Datatype> try_receive(Receiver::timeout_t timeout) override
   {
@@ -71,140 +37,38 @@ public:
   }
   void add_callback(std::function<void(Datatype&)> callback) override { add_callback_impl<Datatype>(callback); }
 
-  void remove_callback() override
-  {
-    std::lock_guard<std::mutex> lk(m_callback_mutex);
-    m_with_callback = false;
-    if (m_event_loop_runner != nullptr && m_event_loop_runner->joinable()) {
-      m_event_loop_runner->join();
-      m_event_loop_runner.reset(nullptr);
-    } else if (m_event_loop_runner != nullptr) {
-      TLOG() << "Event loop can't be closed!";
-    }
-    // remove function.
-  }
+  void remove_callback() override;
 
-  void subscribe(std::string topic) override
-  {
-    if (NetworkManager::get().is_pubsub_connection(this->m_conn)) {
-        std::dynamic_pointer_cast<ipm::Subscriber>(m_network_receiver_ptr)->subscribe(topic);
-    }
-  }
-  void unsubscribe(std::string topic) override
-  {
-    if (NetworkManager::get().is_pubsub_connection(this->m_conn)) {
-        std::dynamic_pointer_cast<ipm::Subscriber>(m_network_receiver_ptr)->unsubscribe(topic);
-    }
-  }
+  void subscribe(std::string topic) override;
+  void unsubscribe(std::string topic) override;
 
 private:
-  void get_receiver(Receiver::timeout_t timeout)
-  {
-    // get network resources
-    auto start = std::chrono::steady_clock::now();
-    while (m_network_receiver_ptr == nullptr &&
-           std::chrono::duration_cast<Receiver::timeout_t>(std::chrono::steady_clock::now() - start) < timeout) {
-
-      try {
-        m_network_receiver_ptr = NetworkManager::get().get_receiver(this->id());
-      } catch (ConnectionNotFound const& ex) {
-        m_network_receiver_ptr = nullptr;
-        std::this_thread::sleep_for(std::chrono::milliseconds(10));
-      }
-    }
-  }
+  void get_receiver(Receiver::timeout_t timeout);
 
   template<typename MessageType>
   typename std::enable_if<dunedaq::serialization::is_serializable<MessageType>::value, MessageType>::type read_network(
-    Receiver::timeout_t const& timeout)
-  {
-    std::lock_guard<std::mutex> lk(m_receive_mutex);
-    get_receiver(timeout);
-
-    if (m_network_receiver_ptr == nullptr) {
-      throw ConnectionInstanceNotFound(ERS_HERE, this->id().uid);
-    }
-
-    auto response = m_network_receiver_ptr->receive(timeout);
-    if (response.data.size() > 0) {
-      return dunedaq::serialization::deserialize<MessageType>(response.data);
-    }
-
-    throw TimeoutExpired(ERS_HERE, this->id().uid, "network receive", timeout.count());
-    return MessageType();
-  }
+    Receiver::timeout_t const& timeout);
 
   template<typename MessageType>
   typename std::enable_if<!dunedaq::serialization::is_serializable<MessageType>::value, MessageType>::type read_network(
-    Receiver::timeout_t const&)
-  {
-    throw NetworkMessageNotSerializable(ERS_HERE, typeid(MessageType).name()); // NOLINT(runtime/rtti)
-    return MessageType();
-  }
+    Receiver::timeout_t const&);
 
   template<typename MessageType>
   typename std::enable_if<dunedaq::serialization::is_serializable<MessageType>::value, std::optional<MessageType>>::type
-  try_read_network(Receiver::timeout_t const& timeout)
-  {
-    std::lock_guard<std::mutex> lk(m_receive_mutex);
-    get_receiver(timeout);
-    if (m_network_receiver_ptr == nullptr) {
-      TLOG() << ConnectionInstanceNotFound(ERS_HERE, this->id().uid);
-      return std::nullopt;
-    }
-
-    ipm::Receiver::Response res;
-    res = m_network_receiver_ptr->receive(timeout, ipm::Receiver::s_any_size, true);
-
-    if (res.data.size() > 0) {
-      return std::make_optional<MessageType>(dunedaq::serialization::deserialize<MessageType>(res.data));
-    }
-
-    return std::nullopt;
-  }
+  try_read_network(Receiver::timeout_t const& timeout);
 
   template<typename MessageType>
   typename std::enable_if<!dunedaq::serialization::is_serializable<MessageType>::value,
                           std::optional<MessageType>>::type
-  try_read_network(Receiver::timeout_t const&)
-  {
-    ers::error(NetworkMessageNotSerializable(ERS_HERE, typeid(MessageType).name())); // NOLINT(runtime/rtti)
-    return std::nullopt;
-  }
+  try_read_network(Receiver::timeout_t const&);
 
   template<typename MessageType>
   typename std::enable_if<dunedaq::serialization::is_serializable<MessageType>::value, void>::type add_callback_impl(
-    std::function<void(MessageType&)> callback)
-  {
-    remove_callback();
-    {
-      std::lock_guard<std::mutex> lk(m_callback_mutex);
-    }
-    TLOG() << "Registering callback.";
-    m_callback = callback;
-    m_with_callback = true;
-    // start event loop (thread that calls when receive happens)
-    m_event_loop_runner = std::make_unique<std::thread>([&]() {
-      std::optional<Datatype> message;
-      while (m_with_callback.load() || message) {
-        try {
-          message = try_read_network<Datatype>(std::chrono::milliseconds(1));
-          if (message) {
-            m_callback(*message);
-          }
-        } catch (const ers::Issue&) {
-          ;
-        }
-      }
-    });
-  }
+    std::function<void(MessageType&)> callback);
 
   template<typename MessageType>
   typename std::enable_if<!dunedaq::serialization::is_serializable<MessageType>::value, void>::type add_callback_impl(
-    std::function<void(MessageType&)>)
-  {
-    throw NetworkMessageNotSerializable(ERS_HERE, typeid(MessageType).name()); // NOLINT(runtime/rtti)
-  }
+    std::function<void(MessageType&)>);
 
   std::atomic<bool> m_with_callback{ false };
   std::function<void(Datatype&)> m_callback;
@@ -216,5 +80,7 @@ private:
 
 } // namespace iomanager
 } // namespace dunedaq
+
+#include "detail/NetworkReceiverModel.hxx"
 
 #endif // IOMANAGER_INCLUDE_IOMANAGER_RECEIVER_HPP_

--- a/include/iomanager/network/detail/NetworkReceiverModel.hxx
+++ b/include/iomanager/network/detail/NetworkReceiverModel.hxx
@@ -1,0 +1,206 @@
+#include "iomanager/Receiver.hpp"
+#include "iomanager/network/NetworkIssues.hpp"
+#include "iomanager/network/NetworkManager.hpp"
+
+#include "ipm/Subscriber.hpp"
+#include "logging/Logging.hpp"
+#include "serialization/Serialization.hpp"
+#include "utilities/ReusableThread.hpp"
+
+#include <atomic>
+#include <memory>
+#include <optional>
+#include <string>
+#include <thread>
+#include <typeinfo>
+#include <utility>
+
+namespace dunedaq {
+
+namespace iomanager {
+
+template<typename Datatype>
+inline NetworkReceiverModel<Datatype>::NetworkReceiverModel(ConnectionId const& conn_id)
+  : ReceiverConcept<Datatype>(conn_id)
+{
+  TLOG() << "NetworkReceiverModel created with DT! ID: " << conn_id.uid << " Addr: " << static_cast<void*>(this);
+  try {
+    get_receiver(std::chrono::milliseconds(1000));
+  } catch (ConnectionNotFound const& ex) {
+    TLOG() << "Initial connection attempt failed: " << ex;
+  }
+}
+
+template<typename Datatype>
+inline NetworkReceiverModel<Datatype>::NetworkReceiverModel(NetworkReceiverModel&& other)
+  : ReceiverConcept<Datatype>(other.m_conn.uid)
+  , m_with_callback(other.m_with_callback.load())
+  , m_callback(std::move(other.m_callback))
+  , m_event_loop_runner(std::move(other.m_event_loop_runner))
+  , m_network_receiver_ptr(std::move(other.m_network_receiver_ptr))
+{
+}
+
+template<typename Datatype>
+inline Datatype
+NetworkReceiverModel<Datatype>::receive(Receiver::timeout_t timeout)
+{
+  try {
+    return read_network<Datatype>(timeout);
+  } catch (ipm::ReceiveTimeoutExpired& ex) {
+    throw TimeoutExpired(ERS_HERE, this->id().uid, "receive", timeout.count(), ex);
+  }
+}
+
+template<typename Datatype>
+inline void
+NetworkReceiverModel<Datatype>::remove_callback()
+{
+  std::lock_guard<std::mutex> lk(m_callback_mutex);
+  m_with_callback = false;
+  if (m_event_loop_runner != nullptr && m_event_loop_runner->joinable()) {
+    m_event_loop_runner->join();
+    m_event_loop_runner.reset(nullptr);
+  } else if (m_event_loop_runner != nullptr) {
+    TLOG() << "Event loop can't be closed!";
+  }
+  // remove function.
+}
+
+template<typename Datatype>
+inline void
+NetworkReceiverModel<Datatype>::subscribe(std::string topic)
+{
+  if (NetworkManager::get().is_pubsub_connection(this->m_conn)) {
+    std::dynamic_pointer_cast<ipm::Subscriber>(m_network_receiver_ptr)->subscribe(topic);
+  }
+}
+
+template<typename Datatype>
+inline void
+NetworkReceiverModel<Datatype>::unsubscribe(std::string topic)
+{
+  if (NetworkManager::get().is_pubsub_connection(this->m_conn)) {
+    std::dynamic_pointer_cast<ipm::Subscriber>(m_network_receiver_ptr)->unsubscribe(topic);
+  }
+}
+
+template<typename Datatype>
+inline void
+NetworkReceiverModel<Datatype>::get_receiver(Receiver::timeout_t timeout)
+{
+  // get network resources
+  auto start = std::chrono::steady_clock::now();
+  while (m_network_receiver_ptr == nullptr &&
+         std::chrono::duration_cast<Receiver::timeout_t>(std::chrono::steady_clock::now() - start) < timeout) {
+
+    try {
+      m_network_receiver_ptr = NetworkManager::get().get_receiver(this->id());
+    } catch (ConnectionNotFound const& ex) {
+      m_network_receiver_ptr = nullptr;
+      std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+  }
+}
+
+template<typename Datatype>
+template<typename MessageType>
+inline typename std::enable_if<dunedaq::serialization::is_serializable<MessageType>::value, MessageType>::type
+NetworkReceiverModel<Datatype>::read_network(Receiver::timeout_t const& timeout)
+{
+  std::lock_guard<std::mutex> lk(m_receive_mutex);
+  get_receiver(timeout);
+
+  if (m_network_receiver_ptr == nullptr) {
+    throw ConnectionInstanceNotFound(ERS_HERE, this->id().uid);
+  }
+
+  auto response = m_network_receiver_ptr->receive(timeout);
+  if (response.data.size() > 0) {
+    return dunedaq::serialization::deserialize<MessageType>(response.data);
+  }
+
+  throw TimeoutExpired(ERS_HERE, this->id().uid, "network receive", timeout.count());
+  return MessageType();
+}
+
+template<typename Datatype>
+template<typename MessageType>
+inline typename std::enable_if<!dunedaq::serialization::is_serializable<MessageType>::value, MessageType>::type
+NetworkReceiverModel<Datatype>::read_network(Receiver::timeout_t const&)
+{
+  throw NetworkMessageNotSerializable(ERS_HERE, typeid(MessageType).name()); // NOLINT(runtime/rtti)
+  return MessageType();
+}
+
+template<typename Datatype>
+template<typename MessageType>
+inline
+  typename std::enable_if<dunedaq::serialization::is_serializable<MessageType>::value, std::optional<MessageType>>::type
+  NetworkReceiverModel<Datatype>::try_read_network(Receiver::timeout_t const& timeout)
+{
+  std::lock_guard<std::mutex> lk(m_receive_mutex);
+  get_receiver(timeout);
+  if (m_network_receiver_ptr == nullptr) {
+    TLOG() << ConnectionInstanceNotFound(ERS_HERE, this->id().uid);
+    return std::nullopt;
+  }
+
+  ipm::Receiver::Response res;
+  res = m_network_receiver_ptr->receive(timeout, ipm::Receiver::s_any_size, true);
+
+  if (res.data.size() > 0) {
+    return std::make_optional<MessageType>(dunedaq::serialization::deserialize<MessageType>(res.data));
+  }
+
+  return std::nullopt;
+}
+
+template<typename Datatype>
+template<typename MessageType>
+inline typename std::enable_if<!dunedaq::serialization::is_serializable<MessageType>::value,
+                               std::optional<MessageType>>::type
+NetworkReceiverModel<Datatype>::try_read_network(Receiver::timeout_t const&)
+{
+  ers::error(NetworkMessageNotSerializable(ERS_HERE, typeid(MessageType).name())); // NOLINT(runtime/rtti)
+  return std::nullopt;
+}
+
+template<typename Datatype>
+template<typename MessageType>
+inline typename std::enable_if<dunedaq::serialization::is_serializable<MessageType>::value, void>::type
+NetworkReceiverModel<Datatype>::add_callback_impl(std::function<void(MessageType&)> callback)
+{
+  remove_callback();
+  {
+    std::lock_guard<std::mutex> lk(m_callback_mutex);
+  }
+  TLOG() << "Registering callback.";
+  m_callback = callback;
+  m_with_callback = true;
+  // start event loop (thread that calls when receive happens)
+  m_event_loop_runner = std::make_unique<std::thread>([&]() {
+    std::optional<Datatype> message;
+    while (m_with_callback.load() || message) {
+      try {
+        message = try_read_network<Datatype>(std::chrono::milliseconds(1));
+        if (message) {
+          m_callback(*message);
+        }
+      } catch (const ers::Issue&) {
+        ;
+      }
+    }
+  });
+}
+
+template<typename Datatype>
+template<typename MessageType>
+inline typename std::enable_if<!dunedaq::serialization::is_serializable<MessageType>::value, void>::type
+NetworkReceiverModel<Datatype>::add_callback_impl(std::function<void(MessageType&)>)
+{
+  throw NetworkMessageNotSerializable(ERS_HERE, typeid(MessageType).name()); // NOLINT(runtime/rtti)
+}
+
+} // namespace iomanager
+} // namespace dunedaq

--- a/include/iomanager/network/detail/NetworkSenderModel.hxx
+++ b/include/iomanager/network/detail/NetworkSenderModel.hxx
@@ -1,0 +1,205 @@
+#include "iomanager/Sender.hpp"
+#include "iomanager/network/NetworkIssues.hpp"
+#include "iomanager/network/NetworkManager.hpp"
+
+#include "ipm/Sender.hpp"
+#include "logging/Logging.hpp"
+#include "serialization/Serialization.hpp"
+
+#include <memory>
+#include <string>
+#include <typeinfo>
+#include <utility>
+
+namespace dunedaq::iomanager {
+
+template<typename Datatype>
+inline NetworkSenderModel<Datatype>::NetworkSenderModel(ConnectionId const& conn_id)
+  : SenderConcept<Datatype>(conn_id)
+{
+  TLOG() << "NetworkSenderModel created with DT! Addr: " << static_cast<void*>(this);
+  try {
+    get_sender(std::chrono::milliseconds(1000));
+  } catch (ConnectionNotFound const& ex) {
+    TLOG() << "Initial connection attempt failed: " << ex;
+  }
+}
+
+template<typename Datatype>
+inline NetworkSenderModel<Datatype>::NetworkSenderModel(NetworkSenderModel&& other)
+  : SenderConcept<Datatype>(other.m_conn.uid)
+  , m_network_sender_ptr(std::move(other.m_network_sender_ptr))
+  , m_topic(std::move(other.m_topic))
+{
+}
+
+template<typename Datatype>
+inline void
+NetworkSenderModel<Datatype>::send(Datatype&& data, Sender::timeout_t timeout) // NOLINT
+{
+  try {
+    write_network<Datatype>(data, timeout);
+  } catch (ipm::SendTimeoutExpired& ex) {
+    throw TimeoutExpired(ERS_HERE, this->id().uid, "send", timeout.count(), ex);
+  }
+}
+
+template<typename Datatype>
+inline bool
+NetworkSenderModel<Datatype>::try_send(Datatype&& data, Sender::timeout_t timeout) // NOLINT
+{
+  return try_write_network<Datatype>(data, timeout);
+}
+
+template<typename Datatype>
+inline void
+NetworkSenderModel<Datatype>::send_with_topic(Datatype&& data, Sender::timeout_t timeout, std::string topic) // NOLINT
+{
+  try {
+    write_network_with_topic<Datatype>(data, timeout, topic);
+  } catch (ipm::SendTimeoutExpired& ex) {
+    throw TimeoutExpired(ERS_HERE, this->id().uid, "send", timeout.count(), ex);
+  }
+}
+
+template<typename Datatype>
+inline void
+NetworkSenderModel<Datatype>::get_sender(Sender::timeout_t const& timeout)
+{
+  auto start = std::chrono::steady_clock::now();
+  while (m_network_sender_ptr == nullptr &&
+         std::chrono::duration_cast<Sender::timeout_t>(std::chrono::steady_clock::now() - start) <= timeout) {
+    // get network resources
+    try {
+      m_network_sender_ptr = NetworkManager::get().get_sender(this->id());
+
+      if (NetworkManager::get().is_pubsub_connection(this->id())) {
+        TLOG() << "Setting topic to " << this->id().data_type;
+        m_topic = this->id().data_type;
+      }
+    } catch (ers::Issue const& ex) {
+      m_network_sender_ptr = nullptr;
+      std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+  }
+}
+
+template<typename Datatype>
+template<typename MessageType>
+inline typename std::enable_if<dunedaq::serialization::is_serializable<MessageType>::value, void>::type
+NetworkSenderModel<Datatype>::write_network(MessageType& message, Sender::timeout_t const& timeout)
+{
+  std::lock_guard<std::mutex> lk(m_send_mutex);
+  get_sender(timeout);
+  if (m_network_sender_ptr == nullptr) {
+    throw TimeoutExpired(
+      ERS_HERE, this->id().uid, "send", timeout.count(), ConnectionInstanceNotFound(ERS_HERE, this->id().uid));
+  }
+
+  auto serialized = dunedaq::serialization::serialize(message, dunedaq::serialization::kMsgPack);
+  //  TLOG() << "Serialized message for network sending: " << serialized.size() << ", topic=" << m_topic << ", this="
+  //  << (void*)this;
+
+  try {
+    m_network_sender_ptr->send(serialized.data(), serialized.size(), extend_first_timeout(timeout), m_topic);
+  } catch (ipm::SendTimeoutExpired const& ex) {
+    TLOG() << "Timeout detected, removing sender to re-acquire connection";
+    NetworkManager::get().remove_sender(this->id());
+    m_network_sender_ptr = nullptr;
+    throw;
+  }
+}
+
+template<typename Datatype>
+template<typename MessageType>
+inline typename std::enable_if<!dunedaq::serialization::is_serializable<MessageType>::value, void>::type
+NetworkSenderModel<Datatype>::write_network(MessageType&, Sender::timeout_t const&)
+{
+  throw NetworkMessageNotSerializable(ERS_HERE, typeid(MessageType).name()); // NOLINT(runtime/rtti)
+}
+
+template<typename Datatype>
+template<typename MessageType>
+inline typename std::enable_if<dunedaq::serialization::is_serializable<MessageType>::value, bool>::type
+NetworkSenderModel<Datatype>::try_write_network(MessageType& message, Sender::timeout_t const& timeout)
+{
+  std::lock_guard<std::mutex> lk(m_send_mutex);
+  get_sender(timeout);
+  if (m_network_sender_ptr == nullptr) {
+    TLOG() << ConnectionInstanceNotFound(ERS_HERE, this->id().uid);
+    return false;
+  }
+
+  auto serialized = dunedaq::serialization::serialize(message, dunedaq::serialization::kMsgPack);
+  // TLOG() << "Serialized message for network sending: " << serialized.size() << ", topic=" << m_topic <<
+  // ", this=" << (void*)this;
+
+  auto res =
+    m_network_sender_ptr->send(serialized.data(), serialized.size(), extend_first_timeout(timeout), m_topic, true);
+  if (!res) {
+    TLOG() << "Timeout detected, removing sender to re-acquire connection";
+    NetworkManager::get().remove_sender(this->id());
+    m_network_sender_ptr = nullptr;
+  }
+  return res;
+}
+
+template<typename Datatype>
+template<typename MessageType>
+inline typename std::enable_if<!dunedaq::serialization::is_serializable<MessageType>::value, bool>::type
+NetworkSenderModel<Datatype>::try_write_network(MessageType&, Sender::timeout_t const&)
+{
+  ers::error(NetworkMessageNotSerializable(ERS_HERE, typeid(MessageType).name())); // NOLINT(runtime/rtti)
+  return false;
+}
+
+template<typename Datatype>
+template<typename MessageType>
+inline typename std::enable_if<dunedaq::serialization::is_serializable<MessageType>::value, void>::type
+NetworkSenderModel<Datatype>::write_network_with_topic(MessageType& message,
+                                                       Sender::timeout_t const& timeout,
+                                                       std::string topic)
+{
+  std::lock_guard<std::mutex> lk(m_send_mutex);
+  get_sender(timeout);
+  if (m_network_sender_ptr == nullptr) {
+    throw TimeoutExpired(
+      ERS_HERE, this->id().uid, "send", timeout.count(), ConnectionInstanceNotFound(ERS_HERE, this->id().uid));
+  }
+
+  auto serialized = dunedaq::serialization::serialize(message, dunedaq::serialization::kMsgPack);
+  //  TLOG() << "Serialized message for network sending: " << serialized.size() << ", topic=" << m_topic << ", this="
+  //  << (void*)this;
+
+  try {
+    m_network_sender_ptr->send(serialized.data(), serialized.size(), timeout, topic);
+  } catch (TimeoutExpired const& ex) {
+    m_network_sender_ptr = nullptr;
+    throw;
+  }
+}
+
+template<typename Datatype>
+template<typename MessageType>
+inline typename std::enable_if<!dunedaq::serialization::is_serializable<MessageType>::value, void>::type
+NetworkSenderModel<Datatype>::write_network_with_topic(MessageType&, Sender::timeout_t const&, std::string)
+{
+  throw NetworkMessageNotSerializable(ERS_HERE, typeid(MessageType).name()); // NOLINT(runtime/rtti)
+}
+
+template<typename Datatype>
+inline Sender::timeout_t
+NetworkSenderModel<Datatype>::extend_first_timeout(Sender::timeout_t timeout)
+{
+  if (m_first) {
+    m_first = false;
+    if (timeout > 1000ms) {
+      return timeout;
+    }
+    return 1000ms;
+  }
+
+  return timeout;
+}
+
+} // namespace dunedaq::iomanager

--- a/include/iomanager/queue/QueueReceiverModel.hpp
+++ b/include/iomanager/queue/QueueReceiverModel.hpp
@@ -10,8 +10,7 @@
 #define IOMANAGER_INCLUDE_IOMANAGER_QRECEIVER_HPP_
 
 #include "iomanager/Receiver.hpp"
-#include "iomanager/queue/QueueIssues.hpp"
-#include "iomanager/queue/QueueRegistry.hpp"
+#include "iomanager/queue/Queue.hpp"
 
 #include "logging/Logging.hpp"
 
@@ -20,8 +19,6 @@
 #include <optional>
 #include <string>
 #include <thread>
-#include <typeinfo>
-#include <utility>
 
 namespace dunedaq {
 namespace iomanager {
@@ -31,100 +28,19 @@ template<typename Datatype>
 class QueueReceiverModel : public ReceiverConcept<Datatype>
 {
 public:
-  explicit QueueReceiverModel(ConnectionId const& request)
-    : ReceiverConcept<Datatype>(request)
-  {
-    TLOG() << "QueueReceiverModel created with DT! Addr: " << this;
-    // get queue ref from queueregistry based on conn_id
-    // std::string sink_name = conn_id to sink_name;
-    // m_source = std::make_unique<appfwk::DAQSource<Datatype>>(sink_name);
-    m_queue = QueueRegistry::get().get_queue<Datatype>(request.uid);
-    TLOG() << "QueueReceiverModel m_queue=" << static_cast<void*>(m_queue.get());
-  }
+  explicit QueueReceiverModel(ConnectionId const& request);
 
-  QueueReceiverModel(QueueReceiverModel&& other)
-    : ReceiverConcept<Datatype>(other.m_conn.uid)
-    , m_with_callback(other.m_with_callback.load())
-    , m_callback(std::move(other.m_callback))
-    , m_event_loop_runner(std::move(other.m_event_loop_runner))
-    , m_queue(std::move(other.m_queue))
-  {
-  }
+  QueueReceiverModel(QueueReceiverModel&& other);
 
   ~QueueReceiverModel() { remove_callback(); }
 
-  Datatype receive(Receiver::timeout_t timeout) override
-  {
-    if (m_with_callback) {
-      TLOG() << "QueueReceiver model is equipped with callback! Ignoring receive call.";
-      throw ReceiveCallbackConflict(ERS_HERE, this->id().uid);
-    }
-    if (m_queue == nullptr) {
-      throw ConnectionInstanceNotFound(ERS_HERE, this->id().uid);
-    }
-    // TLOG() << "Hand off data...";
-    Datatype dt;
-    try {
-      m_queue->pop(dt, timeout);
-    } catch (QueueTimeoutExpired& ex) {
-      throw TimeoutExpired(ERS_HERE, this->id().uid, "pop", timeout.count(), ex);
-    }
-    return dt;
-    // if (m_queue->write(
-  }
+  Datatype receive(Receiver::timeout_t timeout) override;
 
-  std::optional<Datatype> try_receive(Receiver::timeout_t timeout) override
-  {
-    if (m_with_callback) {
-      TLOG() << "QueueReceiver model is equipped with callback! Ignoring receive call.";
-      ers::error(ReceiveCallbackConflict(ERS_HERE, this->id().uid));
-      return std::nullopt;
-    }
-    if (m_queue == nullptr) {
-      ers::error(ConnectionInstanceNotFound(ERS_HERE, this->id().uid));
-      return std::nullopt;
-    }
-    // TLOG() << "Hand off data...";
-    Datatype dt;
-    auto ret = m_queue->try_pop(dt, timeout);
-    if (ret) {
-      return std::make_optional(std::move(dt));
-    }
-    return std::nullopt;
-    // if (m_queue->write(
-  }
+  std::optional<Datatype> try_receive(Receiver::timeout_t timeout) override;
 
-  void add_callback(std::function<void(Datatype&)> callback) override
-  {
-    remove_callback();
-    TLOG() << "Registering callback.";
-    m_callback = callback;
-    m_with_callback = true;
-    // start event loop (thread that calls when receive happens)
-    m_event_loop_runner = std::make_unique<std::thread>([&]() {
-      Datatype dt;
-      bool ret = true;
-      while (m_with_callback.load() || ret) {
-        // TLOG() << "Take data from q then invoke callback...";
-        ret = m_queue->try_pop(dt, std::chrono::milliseconds(1));
-        if (ret) {
-          m_callback(dt);
-        }
-      }
-    });
-  }
+  void add_callback(std::function<void(Datatype&)> callback) override;
 
-  void remove_callback() override
-  {
-    m_with_callback = false;
-    if (m_event_loop_runner != nullptr && m_event_loop_runner->joinable()) {
-      m_event_loop_runner->join();
-      m_event_loop_runner.reset(nullptr);
-    } else if (m_event_loop_runner != nullptr) {
-      TLOG() << "Event loop can't be closed!";
-    }
-    // remove function.
-  }
+  void remove_callback() override;
 
   // Topics are not used for Queues
   void subscribe(std::string) override {}
@@ -139,5 +55,7 @@ private:
 
 } // namespace iomanager
 } // namespace dunedaq
+
+#include "detail/QueueReceiverModel.hxx"
 
 #endif // IOMANAGER_INCLUDE_IOMANAGER_RECEIVER_HPP_

--- a/include/iomanager/queue/QueueSenderModel.hpp
+++ b/include/iomanager/queue/QueueSenderModel.hpp
@@ -10,15 +10,9 @@
 #define IOMANAGER_INCLUDE_IOMANAGER_QSENDER_HPP_
 
 #include "iomanager/Sender.hpp"
-#include "iomanager/queue/QueueIssues.hpp"
-#include "iomanager/queue/QueueRegistry.hpp"
-
-#include "logging/Logging.hpp"
 
 #include <memory>
 #include <string>
-#include <typeinfo>
-#include <utility>
 
 namespace dunedaq::iomanager {
 
@@ -27,53 +21,22 @@ template<typename Datatype>
 class QueueSenderModel : public SenderConcept<Datatype>
 {
 public:
-  explicit QueueSenderModel(ConnectionId const& request)
-    : SenderConcept<Datatype>(request)
-  {
-    TLOG() << "QueueSenderModel created with DT! Addr: " << static_cast<void*>(this);
-    m_queue = QueueRegistry::get().get_queue<Datatype>(request.uid);
-    TLOG() << "QueueSenderModel m_queue=" << static_cast<void*>(m_queue.get());
-    // get queue ref from queueregistry based on conn_id
-  }
+  explicit QueueSenderModel(ConnectionId const& request);
 
-  QueueSenderModel(QueueSenderModel&& other)
-    : SenderConcept<Datatype>(other.m_conn.uid)
-    , m_queue(std::move(other.m_queue))
-  {
-  }
+  QueueSenderModel(QueueSenderModel&& other);
 
-  void send(Datatype&& data, Sender::timeout_t timeout) override // NOLINT
-  {
-    if (m_queue == nullptr)
-      throw ConnectionInstanceNotFound(ERS_HERE, this->id().uid);
+  void send(Datatype&& data, Sender::timeout_t timeout) override;
 
-    try {
-      m_queue->push(std::move(data), timeout);
-    } catch (QueueTimeoutExpired& ex) {
-      throw TimeoutExpired(ERS_HERE, this->id().uid, "push", timeout.count(), ex);
-    }
-  }
+  bool try_send(Datatype&& data, Sender::timeout_t timeout) override;
 
-  bool try_send(Datatype&& data, Sender::timeout_t timeout) override // NOLINT
-  {
-    if (m_queue == nullptr) {
-      ers::error(ConnectionInstanceNotFound(ERS_HERE, this->id().uid));
-      return false;
-    }
-
-    return m_queue->try_push(std::move(data), timeout);
-  }
-
-  void send_with_topic(Datatype&& data, Sender::timeout_t timeout, std::string) override // NOLINT
-  {
-    // Topics are not used for Queues
-    send(std::move(data), timeout);
-  }
+  void send_with_topic(Datatype&& data, Sender::timeout_t timeout, std::string) override;
 
 private:
   std::shared_ptr<Queue<Datatype>> m_queue;
 };
 
 } // namespace dunedaq::iomanager
+
+#include "detail/QueueSenderModel.hxx"
 
 #endif // IOMANAGER_INCLUDE_IOMANAGER_SENDER_HPP_

--- a/include/iomanager/queue/detail/QueueReceiverModel.hxx
+++ b/include/iomanager/queue/detail/QueueReceiverModel.hxx
@@ -1,0 +1,123 @@
+
+#include "iomanager/Receiver.hpp"
+#include "iomanager/queue/QueueIssues.hpp"
+#include "iomanager/queue/QueueRegistry.hpp"
+
+#include "logging/Logging.hpp"
+
+#include <atomic>
+#include <memory>
+#include <optional>
+#include <string>
+#include <thread>
+#include <typeinfo>
+#include <utility>
+
+namespace dunedaq {
+namespace iomanager {
+
+template<typename Datatype>
+inline QueueReceiverModel<Datatype>::QueueReceiverModel(ConnectionId const& request)
+  : ReceiverConcept<Datatype>(request)
+{
+  TLOG() << "QueueReceiverModel created with DT! Addr: " << this;
+  // get queue ref from queueregistry based on conn_id
+  // std::string sink_name = conn_id to sink_name;
+  // m_source = std::make_unique<appfwk::DAQSource<Datatype>>(sink_name);
+  m_queue = QueueRegistry::get().get_queue<Datatype>(request.uid);
+  TLOG() << "QueueReceiverModel m_queue=" << static_cast<void*>(m_queue.get());
+}
+
+template<typename Datatype>
+inline QueueReceiverModel<Datatype>::QueueReceiverModel(QueueReceiverModel&& other)
+  : ReceiverConcept<Datatype>(other.m_conn.uid)
+  , m_with_callback(other.m_with_callback.load())
+  , m_callback(std::move(other.m_callback))
+  , m_event_loop_runner(std::move(other.m_event_loop_runner))
+  , m_queue(std::move(other.m_queue))
+{
+}
+
+template<typename Datatype>
+inline Datatype
+QueueReceiverModel<Datatype>::receive(Receiver::timeout_t timeout)
+{
+  if (m_with_callback) {
+    TLOG() << "QueueReceiver model is equipped with callback! Ignoring receive call.";
+    throw ReceiveCallbackConflict(ERS_HERE, this->id().uid);
+  }
+  if (m_queue == nullptr) {
+    throw ConnectionInstanceNotFound(ERS_HERE, this->id().uid);
+  }
+  // TLOG() << "Hand off data...";
+  Datatype dt;
+  try {
+    m_queue->pop(dt, timeout);
+  } catch (QueueTimeoutExpired& ex) {
+    throw TimeoutExpired(ERS_HERE, this->id().uid, "pop", timeout.count(), ex);
+  }
+  return dt;
+  // if (m_queue->write(
+}
+
+template<typename Datatype>
+inline std::optional<Datatype>
+QueueReceiverModel<Datatype>::try_receive(Receiver::timeout_t timeout)
+{
+  if (m_with_callback) {
+    TLOG() << "QueueReceiver model is equipped with callback! Ignoring receive call.";
+    ers::error(ReceiveCallbackConflict(ERS_HERE, this->id().uid));
+    return std::nullopt;
+  }
+  if (m_queue == nullptr) {
+    ers::error(ConnectionInstanceNotFound(ERS_HERE, this->id().uid));
+    return std::nullopt;
+  }
+  // TLOG() << "Hand off data...";
+  Datatype dt;
+  auto ret = m_queue->try_pop(dt, timeout);
+  if (ret) {
+    return std::make_optional(std::move(dt));
+  }
+  return std::nullopt;
+  // if (m_queue->write(
+}
+
+template<typename Datatype>
+inline void
+QueueReceiverModel<Datatype>::add_callback(std::function<void(Datatype&)> callback)
+{
+  remove_callback();
+  TLOG() << "Registering callback.";
+  m_callback = callback;
+  m_with_callback = true;
+  // start event loop (thread that calls when receive happens)
+  m_event_loop_runner = std::make_unique<std::thread>([&]() {
+    Datatype dt;
+    bool ret = true;
+    while (m_with_callback.load() || ret) {
+      // TLOG() << "Take data from q then invoke callback...";
+      ret = m_queue->try_pop(dt, std::chrono::milliseconds(1));
+      if (ret) {
+        m_callback(dt);
+      }
+    }
+  });
+}
+
+template<typename Datatype>
+inline void
+QueueReceiverModel<Datatype>::remove_callback()
+{
+  m_with_callback = false;
+  if (m_event_loop_runner != nullptr && m_event_loop_runner->joinable()) {
+    m_event_loop_runner->join();
+    m_event_loop_runner.reset(nullptr);
+  } else if (m_event_loop_runner != nullptr) {
+    TLOG() << "Event loop can't be closed!";
+  }
+  // remove function.
+}
+
+} // namespace iomanager
+} // namespace dunedaq

--- a/include/iomanager/queue/detail/QueueSenderModel.hxx
+++ b/include/iomanager/queue/detail/QueueSenderModel.hxx
@@ -1,0 +1,66 @@
+
+#include "iomanager/Sender.hpp"
+#include "iomanager/queue/QueueIssues.hpp"
+#include "iomanager/queue/QueueRegistry.hpp"
+
+#include "logging/Logging.hpp"
+
+#include <memory>
+#include <string>
+#include <typeinfo>
+#include <utility>
+
+namespace dunedaq::iomanager {
+	
+template<typename Datatype>
+inline void
+QueueSenderModel<Datatype>::send_with_topic(Datatype&& data, Sender::timeout_t timeout, std::string) // NOLINT
+{
+  // Topics are not used for Queues
+  send(std::move(data), timeout);
+}
+
+template<typename Datatype>
+inline bool
+QueueSenderModel<Datatype>::try_send(Datatype&& data, Sender::timeout_t timeout) // NOLINT
+{
+  if (m_queue == nullptr) {
+    ers::error(ConnectionInstanceNotFound(ERS_HERE, this->id().uid));
+    return false;
+  }
+
+  return m_queue->try_push(std::move(data), timeout);
+}
+
+template<typename Datatype>
+inline void
+QueueSenderModel<Datatype>::send(Datatype&& data, Sender::timeout_t timeout) // NOLINT
+{
+  if (m_queue == nullptr)
+    throw ConnectionInstanceNotFound(ERS_HERE, this->id().uid);
+
+  try {
+    m_queue->push(std::move(data), timeout);
+  } catch (QueueTimeoutExpired& ex) {
+    throw TimeoutExpired(ERS_HERE, this->id().uid, "push", timeout.count(), ex);
+  }
+}
+
+template<typename Datatype>
+inline QueueSenderModel<Datatype>::QueueSenderModel(QueueSenderModel&& other)
+  : SenderConcept<Datatype>(other.m_conn.uid)
+  , m_queue(std::move(other.m_queue))
+{
+}
+
+template<typename Datatype>
+inline QueueSenderModel<Datatype>::QueueSenderModel(ConnectionId const& request)
+  : SenderConcept<Datatype>(request)
+{
+  TLOG() << "QueueSenderModel created with DT! Addr: " << static_cast<void*>(this);
+  m_queue = QueueRegistry::get().get_queue<Datatype>(request.uid);
+  TLOG() << "QueueSenderModel m_queue=" << static_cast<void*>(m_queue.get());
+  // get queue ref from queueregistry based on conn_id
+}
+
+} // namespace dunedaq::iomanager

--- a/src/IOManager.cpp
+++ b/src/IOManager.cpp
@@ -11,3 +11,53 @@
 #include <memory>
 
 std::shared_ptr<dunedaq::iomanager::IOManager> dunedaq::iomanager::IOManager::s_instance = nullptr;
+
+void
+dunedaq::iomanager::IOManager::configure(Queues_t queues,
+                                         Connections_t connections,
+                                         bool use_config_client,
+                                         std::chrono::milliseconds config_client_interval)
+{
+  char* session = getenv("DUNEDAQ_SESSION");
+  if (session) {
+    m_session = std::string(session);
+  } else {
+    session = getenv("DUNEDAQ_PARTITION");
+    if (session) {
+      m_session = std::string(session);
+    } else {
+      throw(EnvNotFound(ERS_HERE, "DUNEDAQ_SESSION"));
+    }
+  }
+
+  Queues_t qCfg = queues;
+  Connections_t nwCfg;
+
+  for (auto& connection : connections) {
+    nwCfg.push_back(connection);
+  }
+
+  QueueRegistry::get().configure(qCfg);
+  NetworkManager::get().configure(nwCfg, use_config_client, config_client_interval);
+}
+
+void
+dunedaq::iomanager::IOManager::reset()
+{
+  QueueRegistry::get().reset();
+  NetworkManager::get().reset();
+  m_senders.clear();
+  m_receivers.clear();
+  s_instance = nullptr;
+}
+
+std::set<std::string>
+dunedaq::iomanager::IOManager::get_datatypes(std::string const& uid)
+{
+  auto output = QueueRegistry::get().get_datatypes(uid);
+  auto networks = NetworkManager::get().get_datatypes(uid);
+  for (auto& dt : networks) {
+    output.insert(dt);
+  }
+  return output;
+}


### PR DESCRIPTION
for template implementations.

Resolves #57, except most code in IOManager is templated, so there is not much gain in terms of library modularity (e.g. dependencies will still need to be rebuilt when IOManager internals change)