### PR TITLE
Candidate changes to provide a way for user code to tell if Senders are really ready to send data

### DIFF
--- a/include/iomanager/Sender.hpp
+++ b/include/iomanager/Sender.hpp
@@ -49,7 +49,7 @@ public:
   virtual void send(Datatype&& data, Sender::timeout_t timeout) = 0;     // NOLINT
   virtual bool try_send(Datatype&& data, Sender::timeout_t timeout) = 0; // NOLINT
   virtual void send_with_topic(Datatype&& data, Sender::timeout_t timeout, std::string topic) = 0; // NOLINT
-  virtual bool is_ready_for_send(Sender::timeout_t timeout) = 0;         // NOLINT
+  virtual bool is_ready_for_sending(Sender::timeout_t timeout) = 0;      // NOLINT
 };
 
 } // namespace dunedaq::iomanager

--- a/include/iomanager/Sender.hpp
+++ b/include/iomanager/Sender.hpp
@@ -49,6 +49,7 @@ public:
   virtual void send(Datatype&& data, Sender::timeout_t timeout) = 0;     // NOLINT
   virtual bool try_send(Datatype&& data, Sender::timeout_t timeout) = 0; // NOLINT
   virtual void send_with_topic(Datatype&& data, Sender::timeout_t timeout, std::string topic) = 0; // NOLINT
+  virtual bool is_ready_for_send(Sender::timeout_t timeout) = 0;         // NOLINT
 };
 
 } // namespace dunedaq::iomanager

--- a/include/iomanager/network/NetworkSenderModel.hpp
+++ b/include/iomanager/network/NetworkSenderModel.hpp
@@ -37,6 +37,8 @@ public:
 
   void send_with_topic(Datatype&& data, Sender::timeout_t timeout, std::string topic) override;
 
+  bool is_ready_for_send(Sender::timeout_t timeout) override;
+
 private:
   void get_sender(Sender::timeout_t const& timeout);
 

--- a/include/iomanager/network/NetworkSenderModel.hpp
+++ b/include/iomanager/network/NetworkSenderModel.hpp
@@ -37,7 +37,7 @@ public:
 
   void send_with_topic(Datatype&& data, Sender::timeout_t timeout, std::string topic) override;
 
-  bool is_ready_for_send(Sender::timeout_t timeout) override;
+  bool is_ready_for_sending(Sender::timeout_t timeout) override;
 
 private:
   void get_sender(Sender::timeout_t const& timeout);

--- a/include/iomanager/network/detail/NetworkSenderModel.hxx
+++ b/include/iomanager/network/detail/NetworkSenderModel.hxx
@@ -17,11 +17,11 @@ template<typename Datatype>
 inline NetworkSenderModel<Datatype>::NetworkSenderModel(ConnectionId const& conn_id)
   : SenderConcept<Datatype>(conn_id)
 {
-  TLOG() << "NetworkSenderModel created with DT! Addr: " << static_cast<void*>(this);
-  try {
-    get_sender(std::chrono::milliseconds(1000));
-  } catch (ConnectionNotFound const& ex) {
-    TLOG() << "Initial connection attempt failed: " << ex;
+  TLOG() << "NetworkSenderModel created with DT! Addr: " << static_cast<void*>(this)
+         << ", uid=" << conn_id.uid << ", data_type=" << conn_id.data_type;
+  get_sender(std::chrono::milliseconds(1000));
+  if (m_network_sender_ptr == nullptr) {
+    TLOG() << "Initial connection attempt failed for uid=" << conn_id.uid << ", data_type=" << conn_id.data_type;
   }
 }
 
@@ -60,6 +60,14 @@ NetworkSenderModel<Datatype>::send_with_topic(Datatype&& data, Sender::timeout_t
   } catch (ipm::SendTimeoutExpired& ex) {
     throw TimeoutExpired(ERS_HERE, this->id().uid, "send", timeout.count(), ex);
   }
+}
+
+template<typename Datatype>
+inline bool
+NetworkSenderModel<Datatype>::is_ready_for_send(Sender::timeout_t timeout) // NOLINT
+{
+  get_sender(timeout);
+  return (m_network_sender_ptr != nullptr);
 }
 
 template<typename Datatype>

--- a/include/iomanager/network/detail/NetworkSenderModel.hxx
+++ b/include/iomanager/network/detail/NetworkSenderModel.hxx
@@ -64,7 +64,7 @@ NetworkSenderModel<Datatype>::send_with_topic(Datatype&& data, Sender::timeout_t
 
 template<typename Datatype>
 inline bool
-NetworkSenderModel<Datatype>::is_ready_for_send(Sender::timeout_t timeout) // NOLINT
+NetworkSenderModel<Datatype>::is_ready_for_sending(Sender::timeout_t timeout) // NOLINT
 {
   get_sender(timeout);
   return (m_network_sender_ptr != nullptr);

--- a/include/iomanager/queue/QueueSenderModel.hpp
+++ b/include/iomanager/queue/QueueSenderModel.hpp
@@ -31,6 +31,8 @@ public:
 
   void send_with_topic(Datatype&& data, Sender::timeout_t timeout, std::string) override;
 
+  bool is_ready_for_send(Sender::timeout_t timeout) override;
+
 private:
   std::shared_ptr<Queue<Datatype>> m_queue;
 };

--- a/include/iomanager/queue/QueueSenderModel.hpp
+++ b/include/iomanager/queue/QueueSenderModel.hpp
@@ -31,7 +31,7 @@ public:
 
   void send_with_topic(Datatype&& data, Sender::timeout_t timeout, std::string) override;
 
-  bool is_ready_for_send(Sender::timeout_t timeout) override;
+  bool is_ready_for_sending(Sender::timeout_t timeout) override;
 
 private:
   std::shared_ptr<Queue<Datatype>> m_queue;

--- a/include/iomanager/queue/detail/QueueSenderModel.hxx
+++ b/include/iomanager/queue/detail/QueueSenderModel.hxx
@@ -47,6 +47,14 @@ QueueSenderModel<Datatype>::send(Datatype&& data, Sender::timeout_t timeout) // 
 }
 
 template<typename Datatype>
+inline bool
+QueueSenderModel<Datatype>::is_ready_for_send(Sender::timeout_t timeout) // NOLINT
+{
+  // Queues are always ready
+  return true;
+}
+
+template<typename Datatype>
 inline QueueSenderModel<Datatype>::QueueSenderModel(QueueSenderModel&& other)
   : SenderConcept<Datatype>(other.m_conn.uid)
   , m_queue(std::move(other.m_queue))

--- a/include/iomanager/queue/detail/QueueSenderModel.hxx
+++ b/include/iomanager/queue/detail/QueueSenderModel.hxx
@@ -48,7 +48,7 @@ QueueSenderModel<Datatype>::send(Datatype&& data, Sender::timeout_t timeout) // 
 
 template<typename Datatype>
 inline bool
-QueueSenderModel<Datatype>::is_ready_for_send(Sender::timeout_t timeout) // NOLINT
+QueueSenderModel<Datatype>::is_ready_for_sending(Sender::timeout_t /*timeout*/) // NOLINT
 {
   // Queues are always ready
   return true;


### PR DESCRIPTION
In recent running of automated integration tests, I noticed occasional complaints about timeouts sending HSIEvents from FakeHSIEventGenerators to TimingTriggerCandidateMakers.

I found that the underlying problem was that the HSIEvent NetworkSender instance was not quite fully ready to send messages.  

In order to provide a way for the FakeHSIEventGenerator code to check whether the Sender instance is really ready, I've prototyped a new method that provides this information.  These changes are the subject of this PR.

As an aside, I want to mention that I found the existing contents of the NetworkSenderModel constructor *very* confusing.  It had a try/catch block surrounding a method call that doesn't throw an exception.  To help make things more clear, I removed that try/catch block.  With this change, I now correctly see the "Initial connection attempt failed" log message.  Previously, I was not correctly seeing this message in the logs.

The changes in this PR are precursors to ones in a companion PR that I will file soon in the `hsilibs` repo.