### PR TITLE
Add IOManager::senders_are_ready() method to check whether all

### DIFF
--- a/include/iomanager/IOManager.hpp
+++ b/include/iomanager/IOManager.hpp
@@ -54,6 +54,8 @@ public:
 
   void reset();
 
+  bool senders_are_ready();
+
   template<typename Datatype>
   std::shared_ptr<SenderConcept<Datatype>> get_sender(ConnectionId id);
 

--- a/include/iomanager/Sender.hpp
+++ b/include/iomanager/Sender.hpp
@@ -15,6 +15,8 @@
 #include "logging/Logging.hpp"
 #include "utilities/NamedObject.hpp"
 
+#include <string>
+
 namespace dunedaq::iomanager {
 
 // Typeless
@@ -33,6 +35,7 @@ public:
   virtual ~Sender() = default;
 
   ConnectionId id() const { return m_conn; }
+  virtual bool is_ready_for_sending(timeout_t timeout) = 0;
 
 protected:
   ConnectionId m_conn;
@@ -45,11 +48,11 @@ class SenderConcept : public Sender
 public:
   explicit SenderConcept(ConnectionId const& conn_id)
     : Sender(conn_id)
-  {}
-  virtual void send(Datatype&& data, Sender::timeout_t timeout) = 0;     // NOLINT
-  virtual bool try_send(Datatype&& data, Sender::timeout_t timeout) = 0; // NOLINT
-  virtual void send_with_topic(Datatype&& data, Sender::timeout_t timeout, std::string topic) = 0; // NOLINT
-  virtual bool is_ready_for_sending(Sender::timeout_t timeout) = 0;      // NOLINT
+  {
+  }
+  virtual void send(Datatype&& data, Sender::timeout_t timeout) = 0;
+  virtual bool try_send(Datatype&& data, Sender::timeout_t timeout) = 0;
+  virtual void send_with_topic(Datatype&& data, Sender::timeout_t timeout, std::string topic) = 0;
 };
 
 } // namespace dunedaq::iomanager

--- a/src/IOManager.cpp
+++ b/src/IOManager.cpp
@@ -9,6 +9,8 @@
 #include "iomanager/IOManager.hpp"
 
 #include <memory>
+#include <set>
+#include <string>
 
 std::shared_ptr<dunedaq::iomanager::IOManager> dunedaq::iomanager::IOManager::s_instance = nullptr;
 
@@ -49,6 +51,21 @@ dunedaq::iomanager::IOManager::reset()
   m_senders.clear();
   m_receivers.clear();
   s_instance = nullptr;
+}
+
+bool
+dunedaq::iomanager::IOManager::senders_are_ready()
+{
+  auto ready = true;
+
+  for (auto& sender_pair : m_senders) {
+    if (!sender_pair.second->is_ready_for_sending(Sender::timeout_t(1))) {
+      ready = false;
+      break;
+    }
+  }
+
+  return ready;
 }
 
 std::set<std::string>

--- a/unittest/IOManager_test.cxx
+++ b/unittest/IOManager_test.cxx
@@ -251,6 +251,8 @@ BOOST_FIXTURE_TEST_CASE(SimpleSendReceive, ConfigurationTestFixture)
   auto q_sender = IOManager::get()->get_sender<Data>(queue_id);
   auto q_receiver = IOManager::get()->get_receiver<Data>(queue_id);
 
+  BOOST_REQUIRE(IOManager::get()->senders_are_ready());
+
   Data sent_nw(56, 26.5, "test1");
   Data sent_q(57, 27.5, "test2");
   net_sender->send(std::move(sent_nw), dunedaq::iomanager::Sender::s_no_block);
@@ -276,6 +278,8 @@ BOOST_FIXTURE_TEST_CASE(SimplePubSub, ConfigurationTestFixture)
   auto sub1_receiver = IOManager::get()->get_receiver<Data2>(sub1_id);
   auto sub2_receiver = IOManager::get()->get_receiver<Data2>(sub2_id);
   auto sub3_receiver = IOManager::get()->get_receiver<Data3>(sub3_id);
+
+  BOOST_REQUIRE(IOManager::get()->senders_are_ready());
 
   // Sub1 is subscribed to all data_t publishers, Sub2 only to pub2, Sub3 to all data2_t
   Data2 sent_t1(56, 26.5);
@@ -319,6 +323,8 @@ BOOST_FIXTURE_TEST_CASE(PubSubWithTopic, ConfigurationTestFixture)
   auto sub1_receiver = IOManager::get()->get_receiver<Data2>(sub1_id);
   auto sub2_receiver = IOManager::get()->get_receiver<Data2>(sub2_id);
 
+  BOOST_REQUIRE(IOManager::get()->senders_are_ready());
+
   sub1_receiver->subscribe("sub1_topic");
   sub2_receiver->subscribe("sub2_topic");
 
@@ -346,7 +352,7 @@ BOOST_FIXTURE_TEST_CASE(PubSubWithTopic, ConfigurationTestFixture)
   BOOST_REQUIRE_EXCEPTION(
     sub2_receiver->receive(std::chrono::milliseconds(10)), TimeoutExpired, [](TimeoutExpired const&) { return true; });
 
-  Data2 sent_t3{ 57, 27.5};
+  Data2 sent_t3{ 57, 27.5 };
   pub1_sender->send_with_topic(std::move(sent_t3), dunedaq::iomanager::Sender::s_no_block, "sub1_topic");
   ret1 = sub1_receiver->receive(std::chrono::milliseconds(10));
   BOOST_CHECK_EQUAL(ret1.d1, 57);
@@ -377,6 +383,8 @@ BOOST_FIXTURE_TEST_CASE(NonSerializableSendReceive, ConfigurationTestFixture)
   auto q_sender = IOManager::get()->get_sender<NonSerializableData>(queue_id);
   auto q_receiver = IOManager::get()->get_receiver<NonSerializableData>(queue_id);
 
+  BOOST_REQUIRE(IOManager::get()->senders_are_ready());
+
   NonSerializableData sent_nw(56, 26.5, "test1");
   NonSerializableData sent_q(57, 27.5, "test2");
   BOOST_REQUIRE_EXCEPTION(net_sender->send(std::move(sent_nw), dunedaq::iomanager::Sender::s_no_block),
@@ -403,6 +411,8 @@ BOOST_FIXTURE_TEST_CASE(NonCopyableSendReceive, ConfigurationTestFixture)
   auto q_sender = IOManager::get()->get_sender<NonCopyableData>(queue_id);
   auto q_receiver = IOManager::get()->get_receiver<NonCopyableData>(queue_id);
 
+  BOOST_REQUIRE(IOManager::get()->senders_are_ready());
+
   NonCopyableData sent_nw(56, 26.5, "test1");
   NonCopyableData sent_q(57, 27.5, "test2");
   net_sender->send(std::move(sent_nw), dunedaq::iomanager::Sender::s_no_block);
@@ -427,6 +437,8 @@ BOOST_FIXTURE_TEST_CASE(NonSerializableNonCopyableSendReceive, ConfigurationTest
   auto q_sender = IOManager::get()->get_sender<NonSerializableNonCopyable>(queue_id);
   auto q_receiver = IOManager::get()->get_receiver<NonSerializableNonCopyable>(queue_id);
 
+  BOOST_REQUIRE(IOManager::get()->senders_are_ready());
+
   NonSerializableNonCopyable sent_nw(56, 26.5, "test1");
   NonSerializableNonCopyable sent_q(57, 27.5, "test2");
   BOOST_REQUIRE_EXCEPTION(net_sender->send(std::move(sent_nw), dunedaq::iomanager::Sender::s_no_block),
@@ -450,6 +462,8 @@ BOOST_FIXTURE_TEST_CASE(CallbackRegistration, ConfigurationTestFixture)
 {
   auto net_sender = IOManager::get()->get_sender<Data>(conn_id);
   auto q_sender = IOManager::get()->get_sender<Data>(queue_id);
+
+  BOOST_REQUIRE(IOManager::get()->senders_are_ready());
 
   Data sent_data_nw(56, 26.5, "test1");
   Data sent_data_q(57, 27.5, "test2");
@@ -494,6 +508,8 @@ BOOST_FIXTURE_TEST_CASE(NonCopyableCallbackRegistration, ConfigurationTestFixtur
   auto net_sender = IOManager::get()->get_sender<NonCopyableData>(conn_id);
   auto q_sender = IOManager::get()->get_sender<NonCopyableData>(queue_id);
 
+  BOOST_REQUIRE(IOManager::get()->senders_are_ready());
+
   NonCopyableData sent_data_nw(56, 26.5, "test1");
   NonCopyableData sent_data_q(57, 27.5, "test2");
   NonCopyableData recv_data;
@@ -537,6 +553,8 @@ BOOST_FIXTURE_TEST_CASE(NonSerializableCallbackRegistration, ConfigurationTestFi
   auto net_sender = IOManager::get()->get_sender<NonSerializableData>(conn_id);
   auto q_sender = IOManager::get()->get_sender<NonSerializableData>(queue_id);
 
+  BOOST_REQUIRE(IOManager::get()->senders_are_ready());
+
   NonSerializableData sent_data_nw(56, 26.5, "test1");
   NonSerializableData sent_data_q(57, 27.5, "test2");
   NonSerializableData recv_data;
@@ -571,6 +589,8 @@ BOOST_FIXTURE_TEST_CASE(NonSerializableNonCopyableCallbackRegistration, Configur
 {
   auto net_sender = IOManager::get()->get_sender<NonSerializableNonCopyable>(conn_id);
   auto q_sender = IOManager::get()->get_sender<NonSerializableNonCopyable>(queue_id);
+
+  BOOST_REQUIRE(IOManager::get()->senders_are_ready());
 
   NonSerializableNonCopyable sent_data_nw(56, 26.5, "test1");
   NonSerializableNonCopyable sent_data_q(57, 27.5, "test2");


### PR DESCRIPTION
_registered_ Sender instances are ready to send data (i.e. connected to a remote endpoint).