### PR TITLE
Explicitly set the TRACE_NAME in TLOG calls in several hxx files

### DIFF
--- a/include/iomanager/detail/IOManager.hxx
+++ b/include/iomanager/detail/IOManager.hxx
@@ -58,11 +58,11 @@ IOManager::get_receiver(ConnectionId id)
 
   if (!m_receivers.count(id)) {
     if (QueueRegistry::get().has_queue(id.uid, id.data_type)) { // if queue
-      TLOG() << "Creating QueueReceiverModel for uid " << id.uid << ", datatype " << id.data_type;
+      TLOG("IOManager") << "Creating QueueReceiverModel for uid " << id.uid << ", datatype " << id.data_type;
       m_receivers[id] = std::make_shared<QueueReceiverModel<Datatype>>(id);
     } else {
-      TLOG() << "Creating NetworkReceiverModel for uid " << id.uid << ", datatype " << id.data_type << " in session "
-             << id.session;
+      TLOG("IOManager") << "Creating NetworkReceiverModel for uid " << id.uid << ", datatype " << id.data_type
+                        << " in session " << id.session;
       m_receivers[id] = std::make_shared<NetworkReceiverModel<Datatype>>(id);
     }
   }
@@ -98,11 +98,11 @@ IOManager::get_sender(ConnectionId id)
 
   if (!m_senders.count(id)) {
     if (QueueRegistry::get().has_queue(id.uid, id.data_type)) { // if queue
-      TLOG() << "Creating QueueSenderModel for uid " << id.uid << ", datatype " << id.data_type;
+      TLOG("IOManager") << "Creating QueueSenderModel for uid " << id.uid << ", datatype " << id.data_type;
       m_senders[id] = std::make_shared<QueueSenderModel<Datatype>>(id);
     } else {
-      TLOG() << "Creating NetworkSenderModel for uid " << id.uid << ", datatype " << id.data_type << " in session "
-             << id.session;
+      TLOG("IOManager") << "Creating NetworkSenderModel for uid " << id.uid << ", datatype " << id.data_type
+                        << " in session " << id.session;
       m_senders[id] = std::make_shared<NetworkSenderModel<Datatype>>(id);
     }
   }

--- a/include/iomanager/queue/detail/QueueSenderModel.hxx
+++ b/include/iomanager/queue/detail/QueueSenderModel.hxx
@@ -65,9 +65,9 @@ template<typename Datatype>
 inline QueueSenderModel<Datatype>::QueueSenderModel(ConnectionId const& request)
   : SenderConcept<Datatype>(request)
 {
-  TLOG() << "QueueSenderModel created with DT! Addr: " << static_cast<void*>(this);
+  TLOG("QueueSenderModel") << "QueueSenderModel created with DT! Addr: " << static_cast<void*>(this);
   m_queue = QueueRegistry::get().get_queue<Datatype>(request.uid);
-  TLOG() << "QueueSenderModel m_queue=" << static_cast<void*>(m_queue.get());
+  TLOG("QueueSenderModel") << "QueueSenderModel m_queue=" << static_cast<void*>(m_queue.get());
   // get queue ref from queueregistry based on conn_id
 }
 


### PR DESCRIPTION
While running tests of long-window readout with fddaq-v4.2.0 candidate builds, I noticed several TLOG messages showing up in the TRACE buffer with  a TRACE_NAME of TPCTPRequestHandler which was clearly wrong because I didn't have TPG enabled.  This turned out to be TLOG calls in hxx files that didn't have the TRACE_NAME explicitly set.

This PR is filed against the _develop_ branch since it is _not_ intended to be included in the 4.2 release.