### PR TITLE
Add an iomanager::shutdown() method, which destructs all connections

### DIFF
--- a/include/iomanager/IOManager.hpp
+++ b/include/iomanager/IOManager.hpp
@@ -55,6 +55,7 @@ public:
 		 opmonlib::OpMonManager &);
 
   void reset();
+  void shutdown();
 
   template<typename Datatype>
   std::shared_ptr<SenderConcept<Datatype>> get_sender(ConnectionId id);

--- a/include/iomanager/network/NetworkManager.hpp
+++ b/include/iomanager/network/NetworkManager.hpp
@@ -44,6 +44,7 @@ public:
   void configure(const Connections_t& connections, bool use_config_client, std::chrono::milliseconds config_client_interval,
 		 dunedaq::opmonlib::OpMonManager &);
   void reset();
+  void shutdown();
 
   std::shared_ptr<ipm::Receiver> get_receiver(ConnectionId const& conn_id);
   std::shared_ptr<ipm::Sender> get_sender(ConnectionId const& conn_id);

--- a/include/iomanager/queue/QueueRegistry.hpp
+++ b/include/iomanager/queue/QueueRegistry.hpp
@@ -60,6 +60,7 @@ public:
 
   // ONLY TO BE USED FOR TESTING!
   static void reset() { s_instance.reset(nullptr); }
+  void shutdown() { m_queue_registry.clear(); }
 
   bool has_queue(std::string const& uid, std::string const& data_type) const;
 

--- a/src/IOManager.cpp
+++ b/src/IOManager.cpp
@@ -43,6 +43,15 @@ dunedaq::iomanager::IOManager::configure(Queues_t queues,
 }
 
 void
+dunedaq::iomanager::IOManager::shutdown()
+{
+  QueueRegistry::get().shutdown();
+  NetworkManager::get().shutdown();
+  m_senders.clear();
+  m_receivers.clear();
+}
+
+void
 dunedaq::iomanager::IOManager::reset()
 {
   QueueRegistry::get().reset();


### PR DESCRIPTION
while keeping the configuration current.