### PR TITLE
Put frequently-occuring TLOG message at debug level 45.

### DIFF
--- a/include/iomanager/SchemaUtils.hpp
+++ b/include/iomanager/SchemaUtils.hpp
@@ -91,7 +91,7 @@ get_uri_for_connection(const confmodel::NetworkConnection* netCon)
 {
   std::string uri = "";
   if (netCon) {
-    TLOG() << "Getting URI for network connection " << netCon->UID();
+    TLOG_DEBUG(45) << "Getting URI for network connection " << netCon->UID();
     auto service = netCon->get_associated_service();
     if (service->get_protocol() == "tcp") {
 


### PR DESCRIPTION
Resolves #90 

This TLOG is internal to `iomanager`, when it is converting the OKS representation of a connection to a request object for the Connectivity Service.