### PR TITLE
When m_with_callback is false, set timeouts on receive calls to 0, so as

### DIFF
--- a/include/iomanager/network/detail/NetworkReceiverModel.hxx
+++ b/include/iomanager/network/detail/NetworkReceiverModel.hxx
@@ -181,9 +181,10 @@ NetworkReceiverModel<Datatype>::add_callback_impl(std::function<void(MessageType
   // start event loop (thread that calls when receive happens)
   m_event_loop_runner = std::make_unique<std::thread>([&]() {
     std::optional<Datatype> message;
-    while (m_with_callback.load() || message) {
+    while(m_with_callback.load() || message) {
       try {
-        message = try_read_network<Datatype>(std::chrono::milliseconds(20));
+      	// 0 timeout when we are trying to stop
+        message = try_read_network<Datatype>(m_with_callback.load() ? std::chrono::milliseconds(20) : std::chrono::milliseconds(0));
         if (message) {
           m_callback(*message);
         }

--- a/include/iomanager/queue/detail/QueueReceiverModel.hxx
+++ b/include/iomanager/queue/detail/QueueReceiverModel.hxx
@@ -97,7 +97,7 @@ QueueReceiverModel<Datatype>::add_callback(std::function<void(Datatype&)> callba
     bool ret = true;
     while (m_with_callback.load() || ret) {
       // TLOG() << "Take data from q then invoke callback...";
-      ret = m_queue->try_pop(dt, std::chrono::milliseconds(1));
+      ret = m_queue->try_pop(dt, m_with_callback.load() ? std::chrono::milliseconds(1) : std::chrono::milliseconds(0));
       if (ret) {
         m_callback(dt);
       }


### PR DESCRIPTION
to only drain messages which have already been received.

Resolved #93 with extreme prejudice.