### PR TITLE
Fix include for boost/test/unit_test.hpp, apparently

### DIFF
--- a/unittest/FollyQueue_metric_test.cxx
+++ b/unittest/FollyQueue_metric_test.cxx
@@ -11,7 +11,7 @@
 #include "iomanager/queue/FollyQueue.hpp"
 
 #define BOOST_TEST_MODULE FollyQueue_metric_test // NOLINT
-#include "boost/test/included/unit_test.hpp"
+#include "boost/test/unit_test.hpp"
 
 #include <chrono>
 #include <future>

--- a/unittest/FollyQueue_test.cxx
+++ b/unittest/FollyQueue_test.cxx
@@ -10,7 +10,7 @@
 #include "iomanager/queue/FollyQueue.hpp"
 
 #define BOOST_TEST_MODULE FollyQueue_test // NOLINT
-#include "boost/test/included/unit_test.hpp"
+#include "boost/test/unit_test.hpp"
 
 #include <chrono>
 #include <utility>

--- a/unittest/StdDeQueue_test.cxx
+++ b/unittest/StdDeQueue_test.cxx
@@ -10,7 +10,7 @@
 #include "iomanager/queue/StdDeQueue.hpp"
 
 #define BOOST_TEST_MODULE StdDeQueue_test // NOLINT
-#include "boost/test/included/unit_test.hpp"
+#include "boost/test/unit_test.hpp"
 
 #include <chrono>
 


### PR DESCRIPTION
included/unit_test.hpp causes the segfault

Noticed while testing #94 on daq.fnal.gov, apparently this is a recent behavior change from Boost (or c++20).