### PR TITLE
Add explicit JSON serialization macros for communication with the ConnectivityService

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,13 +10,14 @@ find_package(confmodel REQUIRED)
 find_package(ipm REQUIRED)
 find_package(opmonlib REQUIRED)
 find_package(folly REQUIRED)
+find_package(nlohmann_json REQUIRED)
 find_package(serialization REQUIRED)
 find_package(utilities REQUIRED)
 find_package(fmt REQUIRED)
 
 
 ##############################################################################
-set(IOMANAGER_DEPENDENCIES serialization::serialization confmodel::confmodel Folly::folly utilities::utilities opmonlib::opmonlib ipm::ipm fmt::fmt)
+set(IOMANAGER_DEPENDENCIES serialization::serialization confmodel::confmodel Folly::folly utilities::utilities opmonlib::opmonlib ipm::ipm fmt::fmt nlohmann_json::nlohmann_json)
 
 daq_protobuf_codegen( opmon/*.proto )
 

--- a/cmake/iomanagerConfig.cmake.in
+++ b/cmake/iomanagerConfig.cmake.in
@@ -9,6 +9,7 @@ find_dependency(utilities)
 find_dependency(opmonlib)
 find_dependency(ipm)
 find_dependency(folly)
+find_dependency(nlohmann_json)
 
 # Figure out whether or not this dependency is an installed package or
 # in repo form

--- a/include/iomanager/network/ConfigClientStructs.hpp
+++ b/include/iomanager/network/ConfigClientStructs.hpp
@@ -10,7 +10,7 @@
 #define IOMANAGER_INCLUDE_IOMANAGER_CONFIGCLIENTSTRUCTS_HPP_
 
 #include "iomanager/SchemaUtils.hpp"
-#include "serialization/Serialization.hpp"
+#include "nlohmann/json.hpp"
 
 #include <string>
 
@@ -48,8 +48,7 @@ struct ConnectionRequest
     , data_type(convert.data_type)
   {
   }
-
-  DUNE_DAQ_SERIALIZE(ConnectionRequest, uid_regex, data_type);
+  NLOHMANN_DEFINE_TYPE_INTRUSIVE(ConnectionRequest, uid_regex, data_type);
 };
 
 struct ConnectionInfo
@@ -70,7 +69,7 @@ struct ConnectionInfo
   {
   }
 
-  DUNE_DAQ_SERIALIZE(ConnectionInfo, uid, data_type, uri, connection_type);
+  NLOHMANN_DEFINE_TYPE_INTRUSIVE(ConnectionInfo, uid, data_type, uri, connection_type);
 };
 
 struct ConnectionRegistration
@@ -100,14 +99,14 @@ struct ConnectionRegistration
   {
   }
 
-  DUNE_DAQ_SERIALIZE(ConnectionRegistration, uid, data_type, uri, connection_type);
+  NLOHMANN_DEFINE_TYPE_INTRUSIVE(ConnectionRegistration, uid, data_type, uri, connection_type);
 };
 
 struct ConnectionResponse
 {
   std::vector<ConnectionInfo> connections;
 
-  DUNE_DAQ_SERIALIZE(ConnectionResponse, connections);
+  NLOHMANN_DEFINE_TYPE_INTRUSIVE(ConnectionResponse, connections);
 };
 
 inline bool
@@ -120,7 +119,5 @@ operator<(ConnectionRegistration const& l, ConnectionRegistration const& r)
 }
 }
 }
-
-MSGPACK_ADD_ENUM(dunedaq::iomanager::ConnectionType)
 
 #endif // IOMANAGER_INCLUDE_IOMANAGER_CONFIGCLIENTSTRUCTS_HPP_


### PR DESCRIPTION
`serialization` is removing JSON serialization from `DUNE_DAQ_SERIALIZE`. This is the only place where it is actually needed, and can just be encapsulated within the ConfligClientStructs.