### PR TITLE
Johnfreeman/merge fddaq v5.3.2 rc2 a9 into develop

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.12)
-project(iomanager VERSION 2.2.1)
+project(iomanager VERSION 2.2.2)
 
 find_package(daq-cmake REQUIRED)
 

--- a/unittest/IOManager_test.cxx
+++ b/unittest/IOManager_test.cxx
@@ -400,7 +400,7 @@ BOOST_FIXTURE_TEST_CASE(PubSubWithTopic, ConfigurationTestFixture)
   BOOST_CHECK_EQUAL(ret2.d2, 29.5);
 }
 
-BOOST_FIXTURE_TEST_CASE(ConnectionInstanceNotFound, ConfigurationTestFixture)
+BOOST_FIXTURE_TEST_CASE(NotFound, ConfigurationTestFixture)
 {
   ConnectionId bad_id{ "pub4", "data2_t" };
   auto receiver = IOManager::get()->get_receiver<Data2>(bad_id);


### PR DESCRIPTION
In light of the second fddaq-v5.3.2 candidate release, fddaq-v5.3.2-rc2-a9, this PR will merge in the changes from the patch/fddaq-v5.3.x branch of this repo (with any conflicts resolved, if needed, on this source branch for this PR
johnfreeman/merge_fddaq-v5.3.2-rc2-a9_into_develop). A test build using this branch is available at NFDT_DEV_250603_A9.

Merging is only to be done by Software Coordination.
