### PR TITLE
Remove names from TLOG calls, as TRACE now handles header files correctly. Make ConnectionInstanceNotFound messages a TLOG_DEBUG

### DIFF
--- a/include/iomanager/detail/IOManager.hxx
+++ b/include/iomanager/detail/IOManager.hxx
@@ -68,10 +68,10 @@ IOManager::get_receiver(ConnectionId id)
 
   if (!m_receivers.count(id)) {
     if (QueueRegistry::get().has_queue(id.uid, id.data_type)) { // if queue
-      TLOG("IOManager") << "Creating QueueReceiverModel for uid " << id.uid << ", datatype " << id.data_type;
+      TLOG() << "Creating QueueReceiverModel for uid " << id.uid << ", datatype " << id.data_type;
       m_receivers[id] = std::make_shared<QueueReceiverModel<Datatype>>(id);
     } else {
-      TLOG("IOManager") << "Creating NetworkReceiverModel for uid " << id.uid << ", datatype " << id.data_type
+      TLOG() << "Creating NetworkReceiverModel for uid " << id.uid << ", datatype " << id.data_type
                         << " in session " << id.session;
       m_receivers[id] = std::make_shared<NetworkReceiverModel<Datatype>>(id);
     }
@@ -108,10 +108,10 @@ IOManager::get_sender(ConnectionId id)
 
   if (!m_senders.count(id)) {
     if (QueueRegistry::get().has_queue(id.uid, id.data_type)) { // if queue
-      TLOG("IOManager") << "Creating QueueSenderModel for uid " << id.uid << ", datatype " << id.data_type;
+      TLOG() << "Creating QueueSenderModel for uid " << id.uid << ", datatype " << id.data_type;
       m_senders[id] = std::make_shared<QueueSenderModel<Datatype>>(id);
     } else {
-      TLOG("IOManager") << "Creating NetworkSenderModel for uid " << id.uid << ", datatype " << id.data_type
+      TLOG() << "Creating NetworkSenderModel for uid " << id.uid << ", datatype " << id.data_type
                         << " in session " << id.session;
       m_senders[id] = std::make_shared<NetworkSenderModel<Datatype>>(id);
     }

--- a/include/iomanager/network/detail/NetworkReceiverModel.hxx
+++ b/include/iomanager/network/detail/NetworkReceiverModel.hxx
@@ -142,7 +142,7 @@ inline
   std::lock_guard<std::mutex> lk(m_receive_mutex);
   get_receiver(timeout);
   if (m_network_receiver_ptr == nullptr) {
-    TLOG() << ConnectionInstanceNotFound(ERS_HERE, this->id().uid);
+    TLOG_DEBUG(5) << ConnectionInstanceNotFound(ERS_HERE, this->id().uid);
     return std::nullopt;
   }
 

--- a/include/iomanager/network/detail/NetworkSenderModel.hxx
+++ b/include/iomanager/network/detail/NetworkSenderModel.hxx
@@ -17,11 +17,11 @@ template<typename Datatype>
 inline NetworkSenderModel<Datatype>::NetworkSenderModel(ConnectionId const& conn_id)
   : SenderConcept<Datatype>(conn_id)
 {
-  TLOG("NetworkSenderModel") << "NetworkSenderModel created with DT! Addr: " << static_cast<void*>(this)
+  TLOG() << "NetworkSenderModel created with DT! Addr: " << static_cast<void*>(this)
                              << ", uid=" << conn_id.uid << ", data_type=" << conn_id.data_type;
   get_sender(std::chrono::milliseconds(1000));
   if (m_network_sender_ptr == nullptr) {
-    TLOG("NetworkSenderModel") << "Initial connection attempt failed for uid=" << conn_id.uid
+    TLOG() << "Initial connection attempt failed for uid=" << conn_id.uid
                                << ", data_type=" << conn_id.data_type;
   }
 }
@@ -83,7 +83,7 @@ NetworkSenderModel<Datatype>::get_sender(Sender::timeout_t const& timeout)
       m_network_sender_ptr = NetworkManager::get().get_sender(this->id());
 
       if (NetworkManager::get().is_pubsub_connection(this->id())) {
-        TLOG("NetworkSenderModel") << "Setting topic to " << this->id().data_type;
+        TLOG() << "Setting topic to " << this->id().data_type;
         m_topic = this->id().data_type;
       }
     } catch (ers::Issue const& ex) {
@@ -106,14 +106,14 @@ NetworkSenderModel<Datatype>::write_network(MessageType& message, Sender::timeou
   }
 
   auto serialized = dunedaq::serialization::serialize(message, dunedaq::serialization::kMsgPack);
-  //  TLOG("NetworkSenderModel") << "Serialized message for network sending: " << serialized.size() << ", topic=" <<
+  //  TLOG() << "Serialized message for network sending: " << serialized.size() << ", topic=" <<
   //  m_topic << ", this="
   //  << (void*)this;
 
   try {
     m_network_sender_ptr->send(serialized.data(), serialized.size(), extend_first_timeout(timeout), m_topic);
   } catch (ipm::SendTimeoutExpired const& ex) {
-    TLOG("NetworkSenderModel") << "Timeout detected, removing sender to re-acquire connection";
+    TLOG() << "Timeout detected, removing sender to re-acquire connection";
     NetworkManager::get().remove_sender(this->id());
     m_network_sender_ptr = nullptr;
     throw;
@@ -136,19 +136,19 @@ NetworkSenderModel<Datatype>::try_write_network(MessageType& message, Sender::ti
   std::lock_guard<std::mutex> lk(m_send_mutex);
   get_sender(timeout);
   if (m_network_sender_ptr == nullptr) {
-    TLOG("NetworkSenderModel") << ConnectionInstanceNotFound(ERS_HERE, this->id().uid);
+    TLOG_DEBUG(5) << ConnectionInstanceNotFound(ERS_HERE, this->id().uid);
     return false;
   }
 
   auto serialized = dunedaq::serialization::serialize(message, dunedaq::serialization::kMsgPack);
-  // TLOG("NetworkSenderModel") << "Serialized message for network sending: " << serialized.size() << ", topic=" <<
+  // TLOG() << "Serialized message for network sending: " << serialized.size() << ", topic=" <<
   // m_topic <<
   // ", this=" << (void*)this;
 
   auto res =
     m_network_sender_ptr->send(serialized.data(), serialized.size(), extend_first_timeout(timeout), m_topic, true);
   if (!res) {
-    TLOG("NetworkSenderModel") << "Timeout detected, removing sender to re-acquire connection";
+    TLOG() << "Timeout detected, removing sender to re-acquire connection";
     NetworkManager::get().remove_sender(this->id());
     m_network_sender_ptr = nullptr;
   }
@@ -179,7 +179,7 @@ NetworkSenderModel<Datatype>::write_network_with_topic(MessageType& message,
   }
 
   auto serialized = dunedaq::serialization::serialize(message, dunedaq::serialization::kMsgPack);
-  //  TLOG("NetworkSenderModel") << "Serialized message for network sending: " << serialized.size() << ", topic=" <<
+  //  TLOG() << "Serialized message for network sending: " << serialized.size() << ", topic=" <<
   //  m_topic << ", this="
   //  << (void*)this;
 

--- a/include/iomanager/queue/detail/QueueSenderModel.hxx
+++ b/include/iomanager/queue/detail/QueueSenderModel.hxx
@@ -65,9 +65,9 @@ template<typename Datatype>
 inline QueueSenderModel<Datatype>::QueueSenderModel(ConnectionId const& request)
   : SenderConcept<Datatype>(request)
 {
-  TLOG("QueueSenderModel") << "QueueSenderModel created with DT! Addr: " << static_cast<void*>(this);
+  TLOG() << "QueueSenderModel created with DT! Addr: " << static_cast<void*>(this);
   m_queue = QueueRegistry::get().get_queue<Datatype>(request.uid);
-  TLOG("QueueSenderModel") << "QueueSenderModel m_queue=" << static_cast<void*>(m_queue.get());
+  TLOG() << "QueueSenderModel m_queue=" << static_cast<void*>(m_queue.get());
   // get queue ref from queueregistry based on conn_id
 }
 


### PR DESCRIPTION
The ConnectionInstanceNotFound change may help with #48, other changes increase consistency, as the name argument to `TLOG()` was not consistently used, and modern versions of TRACE now handle header files correctly.