### PR TITLE
serialization::serialize now has a default for the second argument

### DIFF
--- a/include/iomanager/network/detail/NetworkSenderModel.hxx
+++ b/include/iomanager/network/detail/NetworkSenderModel.hxx
@@ -107,7 +107,7 @@ NetworkSenderModel<Datatype>::write_network(MessageType& message, Sender::timeou
       ERS_HERE, this->id().uid, "send", timeout.count(), ConnectionInstanceNotFound(ERS_HERE, this->id().uid));
   }
 
-  auto serialized = dunedaq::serialization::serialize(message, dunedaq::serialization::kMsgPack);
+  auto serialized = dunedaq::serialization::serialize(message);
   //  TLOG() << "Serialized message for network sending: " << serialized.size() << ", topic=" <<
   //  m_topic << ", this="
   //  << (void*)this;
@@ -142,7 +142,7 @@ NetworkSenderModel<Datatype>::try_write_network(MessageType& message, Sender::ti
     return false;
   }
 
-  auto serialized = dunedaq::serialization::serialize(message, dunedaq::serialization::kMsgPack);
+  auto serialized = dunedaq::serialization::serialize(message);
   // TLOG() << "Serialized message for network sending: " << serialized.size() << ", topic=" <<
   // m_topic <<
   // ", this=" << (void*)this;
@@ -180,7 +180,7 @@ NetworkSenderModel<Datatype>::write_network_with_topic(MessageType& message,
       ERS_HERE, this->id().uid, "send", timeout.count(), ConnectionInstanceNotFound(ERS_HERE, this->id().uid));
   }
 
-  auto serialized = dunedaq::serialization::serialize(message, dunedaq::serialization::kMsgPack);
+  auto serialized = dunedaq::serialization::serialize(message);
   //  TLOG() << "Serialized message for network sending: " << serialized.size() << ", topic=" <<
   //  m_topic << ", this="
   //  << (void*)this;


### PR DESCRIPTION
After https://github.com/DUNE-DAQ/serialization/pull/31 is merged.