### PR TITLE
Set name for callback threads

### DIFF
--- a/include/iomanager/network/NetworkReceiverModel.hpp
+++ b/include/iomanager/network/NetworkReceiverModel.hpp
@@ -68,9 +68,8 @@ private:
   typename std::enable_if<!serialization::is_serializable<MessageType>::value, void>::type add_callback_impl(
     std::function<void(MessageType&)>);
 
-  std::atomic<bool> m_with_callback{ false };
   std::function<void(Datatype&)> m_callback;
-  std::unique_ptr<std::thread> m_event_loop_runner;
+  std::unique_ptr<std::jthread> m_event_loop_runner;
   std::shared_ptr<ipm::Receiver> m_network_receiver_ptr{ nullptr };
   std::mutex m_callback_mutex;
   std::mutex m_receive_mutex;

--- a/include/iomanager/network/detail/NetworkReceiverModel.hxx
+++ b/include/iomanager/network/detail/NetworkReceiverModel.hxx
@@ -5,7 +5,7 @@
 #include "ipm/Subscriber.hpp"
 #include "logging/Logging.hpp"
 #include "serialization/Serialization.hpp"
-#include "utilities/ReusableThread.hpp"
+#include "utilities/Issues.hpp"
 
 #include <atomic>
 #include <memory>
@@ -32,7 +32,6 @@ inline NetworkReceiverModel<Datatype>::NetworkReceiverModel(ConnectionId const& 
 template<typename Datatype>
 inline NetworkReceiverModel<Datatype>::NetworkReceiverModel(NetworkReceiverModel&& other)
   : ReceiverConcept<Datatype>(other.m_conn.uid)
-  , m_with_callback(other.m_with_callback.load())
   , m_callback(std::move(other.m_callback))
   , m_event_loop_runner(std::move(other.m_event_loop_runner))
   , m_network_receiver_ptr(std::move(other.m_network_receiver_ptr))
@@ -55,13 +54,13 @@ inline void
 NetworkReceiverModel<Datatype>::remove_callback()
 {
   std::lock_guard<std::mutex> lk(m_callback_mutex);
-  m_with_callback = false;
   if (m_event_loop_runner != nullptr && m_event_loop_runner->joinable()) {
+    m_event_loop_runner->request_stop();
     m_event_loop_runner->join();
-    m_event_loop_runner.reset(nullptr);
   } else if (m_event_loop_runner != nullptr) {
     TLOG() << "Event loop can't be closed!";
   }
+  m_event_loop_runner.reset(nullptr);
   // remove function.
 }
 
@@ -174,16 +173,15 @@ NetworkReceiverModel<Datatype>::add_callback_impl(std::function<void(MessageType
   }
   TLOG() << "Registering callback.";
   m_callback = callback;
-  m_with_callback = true;
   // start event loop (thread that calls when receive happens). remove_callback() is called in the destructor, so this
   // will never go out-of-scope while this is running
-  m_event_loop_runner = std::make_unique<std::thread>([&]() {
+  m_event_loop_runner = std::make_unique<std::jthread>([&](std::stop_token token) {
     std::optional<Datatype> message;
-    while (m_with_callback.load() || message) {
+    while (!token.stop_requested() || message) {
       try {
         // 0 timeout when we are trying to stop
-        message = try_read_network<Datatype>(m_with_callback.load() ? std::chrono::milliseconds(20)
-                                                                    : std::chrono::milliseconds(0));
+        message = try_read_network<Datatype>(token.stop_requested() ? std::chrono::milliseconds(0)
+                                                                    : std::chrono::milliseconds(20));
         if (message) {
           m_callback(*message);
         }
@@ -193,6 +191,15 @@ NetworkReceiverModel<Datatype>::add_callback_impl(std::function<void(MessageType
       }
     }
   });
+  auto handle = m_event_loop_runner->native_handle();
+  std::string name = "N_" + this->id().uid;
+  name.resize(15);
+  auto rc = pthread_setname_np(handle, name.c_str());
+  if (rc != 0) {
+    std::ostringstream s;
+    s << "The name " << name << " provided for the thread is too long.";
+    ers::warning(utilities::ThreadingIssue(ERS_HERE, s.str()));
+  }
 }
 
 template<typename Datatype>

--- a/include/iomanager/queue/QueueReceiverModel.hpp
+++ b/include/iomanager/queue/QueueReceiverModel.hpp
@@ -46,9 +46,8 @@ public:
   void unsubscribe(std::string) override {}
 
 private:
-  std::atomic<bool> m_with_callback{ false };
   std::function<void(Datatype&)> m_callback;
-  std::unique_ptr<std::thread> m_event_loop_runner;
+  std::unique_ptr<std::jthread> m_event_loop_runner;
   std::shared_ptr<Queue<Datatype>> m_queue;
 };
 

--- a/include/iomanager/queue/detail/QueueReceiverModel.hxx
+++ b/include/iomanager/queue/detail/QueueReceiverModel.hxx
@@ -4,6 +4,7 @@
 #include "iomanager/queue/QueueRegistry.hpp"
 
 #include "logging/Logging.hpp"
+#include "utilities/Issues.hpp"
 
 #include <atomic>
 #include <memory>
@@ -30,7 +31,6 @@ inline QueueReceiverModel<Datatype>::QueueReceiverModel(ConnectionId const& requ
 template<typename Datatype>
 inline QueueReceiverModel<Datatype>::QueueReceiverModel(QueueReceiverModel&& other)
   : ReceiverConcept<Datatype>(other.m_conn.uid)
-  , m_with_callback(other.m_with_callback.load())
   , m_callback(std::move(other.m_callback))
   , m_event_loop_runner(std::move(other.m_event_loop_runner))
   , m_queue(std::move(other.m_queue))
@@ -41,7 +41,7 @@ template<typename Datatype>
 inline Datatype
 QueueReceiverModel<Datatype>::receive(Receiver::timeout_t timeout)
 {
-  if (m_with_callback) {
+  if (m_event_loop_runner != nullptr) {
     TLOG() << "QueueReceiver model is equipped with callback! Ignoring receive call.";
     throw ReceiveCallbackConflict(ERS_HERE, this->id().uid);
   }
@@ -63,7 +63,7 @@ template<typename Datatype>
 inline std::optional<Datatype>
 QueueReceiverModel<Datatype>::try_receive(Receiver::timeout_t timeout)
 {
-  if (m_with_callback) {
+  if (m_event_loop_runner != nullptr) {
     TLOG() << "QueueReceiver model is equipped with callback! Ignoring receive call.";
     ers::error(ReceiveCallbackConflict(ERS_HERE, this->id().uid));
     return std::nullopt;
@@ -89,27 +89,36 @@ QueueReceiverModel<Datatype>::add_callback(std::function<void(Datatype&)> callba
   remove_callback();
   TLOG() << "Registering callback.";
   m_callback = callback;
-  m_with_callback = true;
   // start event loop (thread that calls when receive happens)
-  m_event_loop_runner = std::make_unique<std::thread>([&]() {
+  m_event_loop_runner = std::make_unique<std::jthread>([&](std::stop_token token) {
     Datatype dt;
     bool ret = true;
-    while (m_with_callback.load() || ret) {
+    while (!token.stop_requested() || ret) {
       // TLOG() << "Take data from q then invoke callback...";
-      ret = m_queue->try_pop(dt, m_with_callback.load() ? std::chrono::milliseconds(1) : std::chrono::milliseconds(0));
+      ret = m_queue->try_pop(dt, token.stop_requested() ? std::chrono::milliseconds(0) 
+          : std::chrono::milliseconds(1));
       if (ret) {
         m_callback(dt);
       }
     }
   });
+  auto handle = m_event_loop_runner->native_handle();
+  std::string name = "Q_" + this->id().uid;
+  name.resize(15);
+  auto rc = pthread_setname_np(handle, name.c_str());
+  if (rc != 0) {
+    std::ostringstream s;
+    s << "The name " << name << " provided for the thread is too long.";
+    ers::warning(utilities::ThreadingIssue(ERS_HERE, s.str()));
+  }
 }
 
 template<typename Datatype>
 inline void
 QueueReceiverModel<Datatype>::remove_callback()
 {
-  m_with_callback = false;
   if (m_event_loop_runner != nullptr && m_event_loop_runner->joinable()) {
+    m_event_loop_runner->request_stop();
     m_event_loop_runner->join();
     m_event_loop_runner.reset(nullptr);
   } else if (m_event_loop_runner != nullptr) {


### PR DESCRIPTION
Set name for callback threads based on type and connection uid
Use std::jthread for callback loops

Note that since the `utilities/ReusableThread.hpp` include was removed from NetworkReceiverModel, several other repositories have reactive changes. PRs for those repos will reference this PR.