### PR TITLE
Additional API for supporting direct callbacks for queues

### DIFF
--- a/include/iomanager/IOManager.hpp
+++ b/include/iomanager/IOManager.hpp
@@ -83,6 +83,15 @@ public:
   void add_callback(std::string const& uid, std::string const& tag, std::function<void(Datatype&)> callback);
 
   template<typename Datatype>
+  void add_direct_callback(ConnectionId const& id, std::function<void(Datatype&&)> callback);
+
+  template<typename Datatype>
+  void add_direct_callback(std::string const& uid, std::function<void(Datatype&&)> callback);
+
+  template<typename Datatype>
+  void add_direct_callback(std::string const& uid, std::string const& tag, std::function<void(Datatype&&)> callback);
+
+  template<typename Datatype>
   void remove_callback(ConnectionId const& id);
 
   template<typename Datatype>

--- a/include/iomanager/Receiver.hpp
+++ b/include/iomanager/Receiver.hpp
@@ -54,6 +54,8 @@ public:
   virtual Datatype receive(Receiver::timeout_t timeout) = 0;
   virtual std::optional<Datatype> try_receive(Receiver::timeout_t timeout) = 0;
   virtual void add_callback(std::function<void(Datatype&)> callback) = 0;
+  virtual bool direct_callbacks_supported() { return false; }
+  virtual void add_direct_callback(std::function<void(Datatype&&)> callback) = 0;
   virtual void remove_callback() = 0;
   virtual void subscribe(std::string topic) = 0;
   virtual void unsubscribe(std::string topic) = 0;

--- a/include/iomanager/detail/IOManager.hxx
+++ b/include/iomanager/detail/IOManager.hxx
@@ -27,6 +27,14 @@ IOManager::add_callback(ConnectionId const& id, std::function<void(Datatype&)> c
 }
 
 template<typename Datatype>
+inline void
+IOManager::add_direct_callback(ConnectionId const& id, std::function<void(Datatype&&)> callback)
+{
+  auto receiver = get_receiver<Datatype>(id);
+  receiver->add_direct_callback(callback);
+}
+
+template<typename Datatype>
 inline std::shared_ptr<ReceiverConcept<Datatype>>
 IOManager::get_receiver(std::string const& uid)
 {
@@ -132,6 +140,22 @@ IOManager::add_callback(std::string const& uid, std::string const& tag, std::fun
 {
   auto receiver = get_receiver<Datatype>(uid, tag);
   receiver->add_callback(callback);
+}
+
+template<typename Datatype>
+inline void
+IOManager::add_direct_callback(std::string const& uid, std::function<void(Datatype&&)> callback)
+{
+  auto receiver = get_receiver<Datatype>(uid);
+  receiver->add_direct_callback(callback);
+}
+
+template<typename Datatype>
+inline void
+IOManager::add_direct_callback(std::string const& uid, std::string const& tag, std::function<void(Datatype&&)> callback)
+{
+  auto receiver = get_receiver<Datatype>(uid, tag);
+  receiver->add_direct_callback(callback);
 }
 
 template<typename Datatype>

--- a/include/iomanager/network/NetworkIssues.hpp
+++ b/include/iomanager/network/NetworkIssues.hpp
@@ -23,6 +23,9 @@ ERS_DECLARE_ISSUE(iomanager,
                   NetworkMessageNotSerializable,
                   "Object of type " << type << " is not serializable but configured for network transfer!",
                   ((std::string)type))
+ERS_DECLARE_ISSUE(iomanager,
+                  DirectCallbacksUnsupported,
+                  "Direct callbacks are not supported by network connections.",)
 
 ERS_DECLARE_ISSUE(iomanager,
                   ConnectionNotFound,

--- a/include/iomanager/network/NetworkReceiverModel.hpp
+++ b/include/iomanager/network/NetworkReceiverModel.hpp
@@ -35,6 +35,7 @@ public:
     return try_read_network<Datatype>(timeout);
   }
   void add_callback(std::function<void(Datatype&)> callback) override { add_callback_impl<Datatype>(callback); }
+  void add_direct_callback(std::function<void(Datatype&&)>) override { throw DirectCallbacksUnsupported(ERS_HERE); }
 
   void remove_callback() override;
 

--- a/include/iomanager/queue/Queue.hpp
+++ b/include/iomanager/queue/Queue.hpp
@@ -87,7 +87,11 @@ public:
   virtual bool try_push(value_t&& val, const duration_t& timeout) = 0;
   virtual bool try_pop(value_t& val, const duration_t& timeout) = 0;
 
+  std::function<void(T&&)> get_callback() { return m_callback; }
+  void set_callback(std::function<void(T&&)> callback) { m_callback = callback; }
+
 private:
+  std::function<void(T&&)> m_callback;
   Queue(const Queue&) = delete;
   Queue& operator=(const Queue&) = delete;
   Queue(Queue&&) = delete;

--- a/include/iomanager/queue/QueueReceiverModel.hpp
+++ b/include/iomanager/queue/QueueReceiverModel.hpp
@@ -39,6 +39,9 @@ public:
 
   void add_callback(std::function<void(Datatype&)> callback) override;
 
+  bool direct_callbacks_supported() override { return true; }
+  void add_direct_callback(std::function<void(Datatype&&)> callback) override;
+
   void remove_callback() override;
 
   // Topics are not used for Queues

--- a/include/iomanager/queue/detail/QueueReceiverModel.hxx
+++ b/include/iomanager/queue/detail/QueueReceiverModel.hxx
@@ -41,12 +41,12 @@ template<typename Datatype>
 inline Datatype
 QueueReceiverModel<Datatype>::receive(Receiver::timeout_t timeout)
 {
-  if (m_event_loop_runner != nullptr) {
-    TLOG() << "QueueReceiver model is equipped with callback! Ignoring receive call.";
-    throw ReceiveCallbackConflict(ERS_HERE, this->id().uid);
-  }
   if (m_queue == nullptr) {
     throw ConnectionInstanceNotFound(ERS_HERE, this->id().uid);
+  }
+  if (m_event_loop_runner != nullptr || m_queue->get_callback()) {
+    TLOG() << "QueueReceiver model is equipped with callback! Ignoring receive call.";
+    throw ReceiveCallbackConflict(ERS_HERE, this->id().uid);
   }
   // TLOG() << "Hand off data...";
   Datatype dt;
@@ -63,13 +63,13 @@ template<typename Datatype>
 inline std::optional<Datatype>
 QueueReceiverModel<Datatype>::try_receive(Receiver::timeout_t timeout)
 {
-  if (m_event_loop_runner != nullptr) {
-    TLOG() << "QueueReceiver model is equipped with callback! Ignoring receive call.";
-    ers::error(ReceiveCallbackConflict(ERS_HERE, this->id().uid));
-    return std::nullopt;
-  }
   if (m_queue == nullptr) {
     ers::error(ConnectionInstanceNotFound(ERS_HERE, this->id().uid));
+    return std::nullopt;
+  }
+  if (m_event_loop_runner != nullptr || m_queue->get_callback()) {
+    TLOG() << "QueueReceiver model is equipped with callback! Ignoring receive call.";
+    ers::error(ReceiveCallbackConflict(ERS_HERE, this->id().uid));
     return std::nullopt;
   }
   // TLOG() << "Hand off data...";
@@ -115,6 +115,19 @@ QueueReceiverModel<Datatype>::add_callback(std::function<void(Datatype&)> callba
 
 template<typename Datatype>
 inline void
+QueueReceiverModel<Datatype>::add_direct_callback(std::function<void(Datatype&&)> callback)
+{
+  remove_callback();
+  TLOG() << "Registering direct callback.";
+
+  if (m_queue == nullptr) {
+    throw ConnectionInstanceNotFound(ERS_HERE, this->id().uid);
+  }
+  m_queue->set_callback(callback);
+}
+
+template<typename Datatype>
+inline void
 QueueReceiverModel<Datatype>::remove_callback()
 {
   if (m_event_loop_runner != nullptr && m_event_loop_runner->joinable()) {
@@ -123,6 +136,9 @@ QueueReceiverModel<Datatype>::remove_callback()
     m_event_loop_runner.reset(nullptr);
   } else if (m_event_loop_runner != nullptr) {
     TLOG() << "Event loop can't be closed!";
+  }
+  if (m_queue != nullptr && m_queue->get_callback()) {
+    m_queue->set_callback(nullptr);
   }
   // remove function.
 }

--- a/include/iomanager/queue/detail/QueueSenderModel.hxx
+++ b/include/iomanager/queue/detail/QueueSenderModel.hxx
@@ -29,6 +29,12 @@ QueueSenderModel<Datatype>::try_send(Datatype&& data, Sender::timeout_t timeout)
     return false;
   }
 
+  auto cb = m_queue->get_callback();
+  if (cb) {
+    cb(std::move(data));
+    return true;
+  }
+
   return m_queue->try_push(std::move(data), timeout);
 }
 
@@ -38,6 +44,12 @@ QueueSenderModel<Datatype>::send(Datatype&& data, Sender::timeout_t timeout) // 
 {
   if (m_queue == nullptr)
     throw ConnectionInstanceNotFound(ERS_HERE, this->id().uid);
+
+  auto cb = m_queue->get_callback();
+  if (cb) {
+    cb(std::move(data));
+    return;
+  }
 
   try {
     m_queue->push(std::move(data), timeout);

--- a/unittest/IOManager_test.cxx
+++ b/unittest/IOManager_test.cxx
@@ -668,6 +668,11 @@ BOOST_FIXTURE_TEST_CASE(DirectCallbackRegistration, ConfigurationTestFixture)
     recv_data = d;
   };
 
+  auto net_recvr = IOManager::get()->get_receiver<Data>(conn_id);
+  auto q_recvr = IOManager::get()->get_receiver<Data>(queue_id);
+  BOOST_REQUIRE(!net_recvr->direct_callbacks_supported());
+  BOOST_REQUIRE(q_recvr->direct_callbacks_supported());
+
   BOOST_REQUIRE_EXCEPTION(IOManager::get()->add_direct_callback<Data>(conn_id, direct_callback),
                           DirectCallbacksUnsupported,
                           [](DirectCallbacksUnsupported const&) { return true; });

--- a/unittest/IOManager_test.cxx
+++ b/unittest/IOManager_test.cxx
@@ -653,6 +653,39 @@ BOOST_FIXTURE_TEST_CASE(NonSerializableNonCopyableCallbackRegistration, Configur
   IOManager::get()->remove_callback<NonSerializableNonCopyable>(queue_id);
 }
 
+BOOST_FIXTURE_TEST_CASE(DirectCallbackRegistration, ConfigurationTestFixture)
+{
+  auto net_sender = IOManager::get()->get_sender<Data>(conn_id);
+  auto q_sender = IOManager::get()->get_sender<Data>(queue_id);
+
+  Data sent_data_nw(56, 26.5, "test1");
+  Data sent_data_q(57, 27.5, "test2");
+  Data recv_data;
+  std::atomic<bool> has_received_data = false;
+
+  std::function<void(Data&&)> direct_callback = [&](Data&& d) {
+    has_received_data = true;
+    recv_data = d;
+  };
+
+  BOOST_REQUIRE_EXCEPTION(IOManager::get()->add_direct_callback<Data>(conn_id, direct_callback),
+                          DirectCallbacksUnsupported,
+                          [](DirectCallbacksUnsupported const&) { return true; });
+  IOManager::get()->add_direct_callback<Data>(queue_id, direct_callback);
+
+  has_received_data = false;
+  q_sender->send(std::move(sent_data_q), std::chrono::milliseconds(10));
+  // Synchronous
+  BOOST_REQUIRE(has_received_data);
+
+  BOOST_CHECK_EQUAL(recv_data.d1, 57);
+  BOOST_CHECK_EQUAL(recv_data.d2, 27.5);
+  BOOST_CHECK_EQUAL(recv_data.d3, "test2");
+
+  IOManager::get()->remove_callback<Data>(conn_id);
+  IOManager::get()->remove_callback<Data>(queue_id);
+}
+
 BOOST_FIXTURE_TEST_CASE(GetDatatype, ConfigurationTestFixture)
 {
   auto networkDataTypes = IOManager::get()->get_datatypes("network");


### PR DESCRIPTION
, allowing to bypass the queue entirely and transfer data via a std::move call. (Note that the callback is executed on the senders thread.)