### PR TITLE
Direct Callbacks using Queue configuration (unified API)

### DIFF
--- a/include/iomanager/IOManager.hpp
+++ b/include/iomanager/IOManager.hpp
@@ -74,22 +74,13 @@ public:
   std::shared_ptr<ReceiverConcept<Datatype>> get_receiver(std::string const& uid, std::string const& tag);
 
   template<typename Datatype>
-  void add_callback(ConnectionId const& id, std::function<void(Datatype&)> callback);
+  void add_callback(ConnectionId const& id, std::function<void(Datatype&&)> callback);
 
   template<typename Datatype>
-  void add_callback(std::string const& uid, std::function<void(Datatype&)> callback);
+  void add_callback(std::string const& uid, std::function<void(Datatype&&)> callback);
 
   template<typename Datatype>
-  void add_callback(std::string const& uid, std::string const& tag, std::function<void(Datatype&)> callback);
-
-  template<typename Datatype>
-  void add_direct_callback(ConnectionId const& id, std::function<void(Datatype&&)> callback);
-
-  template<typename Datatype>
-  void add_direct_callback(std::string const& uid, std::function<void(Datatype&&)> callback);
-
-  template<typename Datatype>
-  void add_direct_callback(std::string const& uid, std::string const& tag, std::function<void(Datatype&&)> callback);
+  void add_callback(std::string const& uid, std::string const& tag, std::function<void(Datatype&&)> callback);
 
   template<typename Datatype>
   void remove_callback(ConnectionId const& id);

--- a/include/iomanager/IOManager.hpp
+++ b/include/iomanager/IOManager.hpp
@@ -83,6 +83,15 @@ public:
   void add_callback(std::string const& uid, std::string const& tag, std::function<void(Datatype&)> callback);
 
   template<typename Datatype>
+  void add_direct_callback(ConnectionId const& id, std::function<void(Datatype&&)> callback);
+
+  template<typename Datatype>
+  void add_direct_callback(std::string const& uid, std::function<void(Datatype&&)> callback);
+
+  template<typename Datatype>
+  void add_direct_callback(std::string const& uid, std::string const& tag, std::function<void(Datatype&&)> callback);
+
+  template<typename Datatype>
   void remove_callback(ConnectionId const& id);
 
   template<typename Datatype>

--- a/include/iomanager/Receiver.hpp
+++ b/include/iomanager/Receiver.hpp
@@ -53,9 +53,8 @@ public:
   }
   virtual Datatype receive(Receiver::timeout_t timeout) = 0;
   virtual std::optional<Datatype> try_receive(Receiver::timeout_t timeout) = 0;
-  virtual void add_callback(std::function<void(Datatype&)> callback) = 0;
-  virtual bool direct_callbacks_supported() { return false; }
-  virtual void add_direct_callback(std::function<void(Datatype&&)> callback) = 0;
+  virtual void add_callback(std::function<void(Datatype&&)> callback) = 0;
+  virtual bool direct_callbacks_enabled() { return false; }
   virtual void remove_callback() = 0;
   virtual void subscribe(std::string topic) = 0;
   virtual void unsubscribe(std::string topic) = 0;

--- a/include/iomanager/Receiver.hpp
+++ b/include/iomanager/Receiver.hpp
@@ -54,6 +54,8 @@ public:
   virtual Datatype receive(Receiver::timeout_t timeout) = 0;
   virtual std::optional<Datatype> try_receive(Receiver::timeout_t timeout) = 0;
   virtual void add_callback(std::function<void(Datatype&)> callback) = 0;
+  virtual bool direct_callbacks_supported() { return false; }
+  virtual void add_direct_callback(std::function<void(Datatype&&)> callback) = 0;
   virtual void remove_callback() = 0;
   virtual void subscribe(std::string topic) = 0;
   virtual void unsubscribe(std::string topic) = 0;

--- a/include/iomanager/detail/IOManager.hxx
+++ b/include/iomanager/detail/IOManager.hxx
@@ -20,18 +20,10 @@ namespace iomanager {
 
 template<typename Datatype>
 inline void
-IOManager::add_callback(ConnectionId const& id, std::function<void(Datatype&)> callback)
+IOManager::add_callback(ConnectionId const& id, std::function<void(Datatype&&)> callback)
 {
   auto receiver = get_receiver<Datatype>(id);
   receiver->add_callback(callback);
-}
-
-template<typename Datatype>
-inline void
-IOManager::add_direct_callback(ConnectionId const& id, std::function<void(Datatype&&)> callback)
-{
-  auto receiver = get_receiver<Datatype>(id);
-  receiver->add_direct_callback(callback);
 }
 
 template<typename Datatype>
@@ -128,7 +120,7 @@ IOManager::get_sender(ConnectionId id)
 
 template<typename Datatype>
 inline void
-IOManager::add_callback(std::string const& uid, std::function<void(Datatype&)> callback)
+IOManager::add_callback(std::string const& uid, std::function<void(Datatype&&)> callback)
 {
   auto receiver = get_receiver<Datatype>(uid);
   receiver->add_callback(callback);
@@ -136,26 +128,10 @@ IOManager::add_callback(std::string const& uid, std::function<void(Datatype&)> c
 
 template<typename Datatype>
 inline void
-IOManager::add_callback(std::string const& uid, std::string const& tag, std::function<void(Datatype&)> callback)
+IOManager::add_callback(std::string const& uid, std::string const& tag, std::function<void(Datatype&&)> callback)
 {
   auto receiver = get_receiver<Datatype>(uid, tag);
   receiver->add_callback(callback);
-}
-
-template<typename Datatype>
-inline void
-IOManager::add_direct_callback(std::string const& uid, std::function<void(Datatype&&)> callback)
-{
-  auto receiver = get_receiver<Datatype>(uid);
-  receiver->add_direct_callback(callback);
-}
-
-template<typename Datatype>
-inline void
-IOManager::add_direct_callback(std::string const& uid, std::string const& tag, std::function<void(Datatype&&)> callback)
-{
-  auto receiver = get_receiver<Datatype>(uid, tag);
-  receiver->add_direct_callback(callback);
 }
 
 template<typename Datatype>

--- a/include/iomanager/detail/IOManager.hxx
+++ b/include/iomanager/detail/IOManager.hxx
@@ -27,6 +27,14 @@ IOManager::add_callback(ConnectionId const& id, std::function<void(Datatype&)> c
 }
 
 template<typename Datatype>
+inline void
+IOManager::add_direct_callback(ConnectionId const& id, std::function<void(Datatype&&)> callback)
+{
+  auto receiver = get_receiver<Datatype>(id);
+  receiver->add_direct_callback(callback);
+}
+
+template<typename Datatype>
 inline std::shared_ptr<ReceiverConcept<Datatype>>
 IOManager::get_receiver(std::string const& uid)
 {
@@ -132,6 +140,22 @@ IOManager::add_callback(std::string const& uid, std::string const& tag, std::fun
 {
   auto receiver = get_receiver<Datatype>(uid, tag);
   receiver->add_callback(callback);
+}
+
+template<typename Datatype>
+inline void
+IOManager::add_direct_callback(std::string const& uid, std::function<void(Datatype&&)> callback)
+{
+  auto receiver = get_receiver<Datatype>(uid);
+  receiver->add_direct_callback(callback);
+}
+
+template<typename Datatype>
+inline void
+IOManager::add_direct_callback(std::string const& uid, std::string const& tag, std::function<void(Datatype&&)> callback)
+{
+  auto receiver = get_receiver<Datatype>(uid, tag);
+  receiver->add_direct_callback(callback);
 }
 
 template<typename Datatype>

--- a/include/iomanager/network/NetworkIssues.hpp
+++ b/include/iomanager/network/NetworkIssues.hpp
@@ -23,6 +23,9 @@ ERS_DECLARE_ISSUE(iomanager,
                   NetworkMessageNotSerializable,
                   "Object of type " << type << " is not serializable but configured for network transfer!",
                   ((std::string)type))
+ERS_DECLARE_ISSUE(iomanager,
+                  DirectCallbacksUnsupported,
+                  "Direct callbacks are not supported by network connections.",)
 
 ERS_DECLARE_ISSUE(iomanager,
                   ConnectionNotFound,

--- a/include/iomanager/network/NetworkReceiverModel.hpp
+++ b/include/iomanager/network/NetworkReceiverModel.hpp
@@ -35,6 +35,7 @@ public:
     return try_read_network<Datatype>(timeout);
   }
   void add_callback(std::function<void(Datatype&)> callback) override { add_callback_impl<Datatype>(callback); }
+  void add_direct_callback(std::function<void(Datatype&&)>) override { throw DirectCallbacksUnsupported(ERS_HERE); }
 
   void remove_callback() override;
 

--- a/include/iomanager/network/NetworkReceiverModel.hpp
+++ b/include/iomanager/network/NetworkReceiverModel.hpp
@@ -34,8 +34,7 @@ public:
   {
     return try_read_network<Datatype>(timeout);
   }
-  void add_callback(std::function<void(Datatype&)> callback) override { add_callback_impl<Datatype>(callback); }
-  void add_direct_callback(std::function<void(Datatype&&)>) override { throw DirectCallbacksUnsupported(ERS_HERE); }
+  void add_callback(std::function<void(Datatype&&)> callback) override { add_callback_impl<Datatype>(callback); }
 
   void remove_callback() override;
 
@@ -63,13 +62,13 @@ private:
 
   template<typename MessageType>
   typename std::enable_if<serialization::is_serializable<MessageType>::value, void>::type add_callback_impl(
-    std::function<void(MessageType&)> callback);
+    std::function<void(MessageType&&)> callback);
 
   template<typename MessageType>
   typename std::enable_if<!serialization::is_serializable<MessageType>::value, void>::type add_callback_impl(
-    std::function<void(MessageType&)>);
+    std::function<void(MessageType&&)>);
 
-  std::function<void(Datatype&)> m_callback;
+  std::function<void(Datatype&&)> m_callback;
   std::unique_ptr<std::jthread> m_event_loop_runner;
   std::shared_ptr<ipm::Receiver> m_network_receiver_ptr{ nullptr };
   std::mutex m_callback_mutex;

--- a/include/iomanager/network/detail/NetworkReceiverModel.hxx
+++ b/include/iomanager/network/detail/NetworkReceiverModel.hxx
@@ -164,7 +164,7 @@ NetworkReceiverModel<Datatype>::try_read_network(Receiver::timeout_t const&)
 template<typename Datatype>
 template<typename MessageType>
 inline typename std::enable_if<serialization::is_serializable<MessageType>::value, void>::type
-NetworkReceiverModel<Datatype>::add_callback_impl(std::function<void(MessageType&)> callback)
+NetworkReceiverModel<Datatype>::add_callback_impl(std::function<void(MessageType&&)> callback)
 {
   remove_callback();
   {
@@ -183,7 +183,7 @@ NetworkReceiverModel<Datatype>::add_callback_impl(std::function<void(MessageType
         message = try_read_network<Datatype>(token.stop_requested() ? std::chrono::milliseconds(0)
                                                                     : std::chrono::milliseconds(20));
         if (message) {
-          m_callback(*message);
+          m_callback(std::move(*message));
         }
       } catch (const ers::Issue&) {
         // Intentionally ignoring any ers::Issues that might have been raised
@@ -205,7 +205,7 @@ NetworkReceiverModel<Datatype>::add_callback_impl(std::function<void(MessageType
 template<typename Datatype>
 template<typename MessageType>
 inline typename std::enable_if<!serialization::is_serializable<MessageType>::value, void>::type
-NetworkReceiverModel<Datatype>::add_callback_impl(std::function<void(MessageType&)>)
+NetworkReceiverModel<Datatype>::add_callback_impl(std::function<void(MessageType&&)>)
 {
   throw NetworkMessageNotSerializable(ERS_HERE, typeid(MessageType).name()); // NOLINT(runtime/rtti)
 }

--- a/include/iomanager/queue/Queue.hpp
+++ b/include/iomanager/queue/Queue.hpp
@@ -87,7 +87,11 @@ public:
   virtual bool try_push(value_t&& val, const duration_t& timeout) = 0;
   virtual bool try_pop(value_t& val, const duration_t& timeout) = 0;
 
+  std::function<void(T&&)> get_callback() { return m_callback; }
+  void set_callback(std::function<void(T&&)> callback) { m_callback = callback; }
+
 private:
+  std::function<void(T&&)> m_callback;
   Queue(const Queue&) = delete;
   Queue& operator=(const Queue&) = delete;
   Queue(Queue&&) = delete;

--- a/include/iomanager/queue/QueueBase.hpp
+++ b/include/iomanager/queue/QueueBase.hpp
@@ -62,6 +62,9 @@ public:
 
   virtual size_t get_num_elements() const = 0;
 
+  bool direct_callbacks_enabled() const { return m_direct_callbacks_enabled; };
+  void set_direct_callbacks_enabled(bool enabled) { m_direct_callbacks_enabled = enabled; }
+
 protected:
   /**
    * @brief Method to retrieve information (occupancy) from
@@ -80,6 +83,8 @@ private:
   QueueBase& operator=(const QueueBase&) = delete;
   QueueBase(QueueBase&&) = delete;
   QueueBase& operator=(QueueBase&&) = delete;
+
+  bool m_direct_callbacks_enabled;
 };
 
 } // namespace dunedaq::iomanager

--- a/include/iomanager/queue/QueueReceiverModel.hpp
+++ b/include/iomanager/queue/QueueReceiverModel.hpp
@@ -37,10 +37,9 @@ public:
 
   std::optional<Datatype> try_receive(Receiver::timeout_t timeout) override;
 
-  void add_callback(std::function<void(Datatype&)> callback) override;
+  void add_callback(std::function<void(Datatype&&)> callback) override;
 
-  bool direct_callbacks_supported() override { return true; }
-  void add_direct_callback(std::function<void(Datatype&&)> callback) override;
+  bool direct_callbacks_enabled() override { return m_queue->direct_callbacks_enabled(); }
 
   void remove_callback() override;
 
@@ -49,7 +48,7 @@ public:
   void unsubscribe(std::string) override {}
 
 private:
-  std::function<void(Datatype&)> m_callback;
+  std::function<void(Datatype&&)> m_callback;
   std::unique_ptr<std::jthread> m_event_loop_runner;
   std::shared_ptr<Queue<Datatype>> m_queue;
 };

--- a/include/iomanager/queue/QueueReceiverModel.hpp
+++ b/include/iomanager/queue/QueueReceiverModel.hpp
@@ -39,6 +39,9 @@ public:
 
   void add_callback(std::function<void(Datatype&)> callback) override;
 
+  bool direct_callbacks_supported() override { return true; }
+  void add_direct_callback(std::function<void(Datatype&&)> callback) override;
+
   void remove_callback() override;
 
   // Topics are not used for Queues

--- a/include/iomanager/queue/detail/QueueReceiverModel.hxx
+++ b/include/iomanager/queue/detail/QueueReceiverModel.hxx
@@ -41,12 +41,12 @@ template<typename Datatype>
 inline Datatype
 QueueReceiverModel<Datatype>::receive(Receiver::timeout_t timeout)
 {
-  if (m_event_loop_runner != nullptr) {
-    TLOG() << "QueueReceiver model is equipped with callback! Ignoring receive call.";
-    throw ReceiveCallbackConflict(ERS_HERE, this->id().uid);
-  }
   if (m_queue == nullptr) {
     throw ConnectionInstanceNotFound(ERS_HERE, this->id().uid);
+  }
+  if (m_event_loop_runner != nullptr || m_queue->get_callback()) {
+    TLOG() << "QueueReceiver model is equipped with callback! Ignoring receive call.";
+    throw ReceiveCallbackConflict(ERS_HERE, this->id().uid);
   }
   // TLOG() << "Hand off data...";
   Datatype dt;
@@ -63,13 +63,13 @@ template<typename Datatype>
 inline std::optional<Datatype>
 QueueReceiverModel<Datatype>::try_receive(Receiver::timeout_t timeout)
 {
-  if (m_event_loop_runner != nullptr) {
-    TLOG() << "QueueReceiver model is equipped with callback! Ignoring receive call.";
-    ers::error(ReceiveCallbackConflict(ERS_HERE, this->id().uid));
-    return std::nullopt;
-  }
   if (m_queue == nullptr) {
     ers::error(ConnectionInstanceNotFound(ERS_HERE, this->id().uid));
+    return std::nullopt;
+  }
+  if (m_event_loop_runner != nullptr || m_queue->get_callback()) {
+    TLOG() << "QueueReceiver model is equipped with callback! Ignoring receive call.";
+    ers::error(ReceiveCallbackConflict(ERS_HERE, this->id().uid));
     return std::nullopt;
   }
   // TLOG() << "Hand off data...";
@@ -115,6 +115,19 @@ QueueReceiverModel<Datatype>::add_callback(std::function<void(Datatype&)> callba
 
 template<typename Datatype>
 inline void
+QueueReceiverModel<Datatype>::add_direct_callback(std::function<void(Datatype&&)> callback)
+{
+  remove_callback();
+  TLOG() << "Registering direct callback.";
+
+  if (m_queue == nullptr) {
+    throw ConnectionInstanceNotFound(ERS_HERE, this->id().uid);
+  }
+  m_queue->set_callback(callback);
+}
+
+template<typename Datatype>
+inline void
 QueueReceiverModel<Datatype>::remove_callback()
 {
   if (m_event_loop_runner != nullptr && m_event_loop_runner->joinable()) {
@@ -123,6 +136,9 @@ QueueReceiverModel<Datatype>::remove_callback()
     m_event_loop_runner.reset(nullptr);
   } else if (m_event_loop_runner != nullptr) {
     TLOG() << "Event loop can't be closed!";
+  }
+  if (m_queue != nullptr && m_queue->get_callback()) {
+    m_queue->set_callback(nullptr);
   }
   // remove function.
 }

--- a/include/iomanager/queue/detail/QueueReceiverModel.hxx
+++ b/include/iomanager/queue/detail/QueueReceiverModel.hxx
@@ -84,46 +84,43 @@ QueueReceiverModel<Datatype>::try_receive(Receiver::timeout_t timeout)
 
 template<typename Datatype>
 inline void
-QueueReceiverModel<Datatype>::add_callback(std::function<void(Datatype&)> callback)
+QueueReceiverModel<Datatype>::add_callback(std::function<void(Datatype&&)> callback)
 {
   remove_callback();
   TLOG() << "Registering callback.";
-  m_callback = callback;
-  // start event loop (thread that calls when receive happens)
-  m_event_loop_runner = std::make_unique<std::jthread>([&](std::stop_token token) {
-    Datatype dt;
-    bool ret = true;
-    while (!token.stop_requested() || ret) {
-      // TLOG() << "Take data from q then invoke callback...";
-      ret = m_queue->try_pop(dt, token.stop_requested() ? std::chrono::milliseconds(0) 
-          : std::chrono::milliseconds(1));
-      if (ret) {
-        m_callback(dt);
-      }
+  if (m_queue->direct_callbacks_enabled()) {
+    TLOG() << "Registering direct callback.";
+
+    if (m_queue == nullptr) {
+      throw ConnectionInstanceNotFound(ERS_HERE, this->id().uid);
     }
-  });
-  auto handle = m_event_loop_runner->native_handle();
-  std::string name = "Q_" + this->id().uid;
-  name.resize(15);
-  auto rc = pthread_setname_np(handle, name.c_str());
-  if (rc != 0) {
-    std::ostringstream s;
-    s << "The name " << name << " provided for the thread is too long.";
-    ers::warning(utilities::ThreadingIssue(ERS_HERE, s.str()));
-  }
-}
+    m_queue->set_callback(callback);
+  } else {
 
-template<typename Datatype>
-inline void
-QueueReceiverModel<Datatype>::add_direct_callback(std::function<void(Datatype&&)> callback)
-{
-  remove_callback();
-  TLOG() << "Registering direct callback.";
-
-  if (m_queue == nullptr) {
-    throw ConnectionInstanceNotFound(ERS_HERE, this->id().uid);
+    m_callback = callback;
+    // start event loop (thread that calls when receive happens)
+    m_event_loop_runner = std::make_unique<std::jthread>([&](std::stop_token token) {
+      Datatype dt;
+      bool ret = true;
+      while (!token.stop_requested() || ret) {
+        // TLOG() << "Take data from q then invoke callback...";
+        ret =
+          m_queue->try_pop(dt, token.stop_requested() ? std::chrono::milliseconds(0) : std::chrono::milliseconds(1));
+        if (ret) {
+          m_callback(std::move(dt));
+        }
+      }
+    });
+    auto handle = m_event_loop_runner->native_handle();
+    std::string name = "Q_" + this->id().uid;
+    name.resize(15);
+    auto rc = pthread_setname_np(handle, name.c_str());
+    if (rc != 0) {
+      std::ostringstream s;
+      s << "The name " << name << " provided for the thread is too long.";
+      ers::warning(utilities::ThreadingIssue(ERS_HERE, s.str()));
+    }
   }
-  m_queue->set_callback(callback);
 }
 
 template<typename Datatype>

--- a/include/iomanager/queue/detail/QueueRegistry.hxx
+++ b/include/iomanager/queue/detail/QueueRegistry.hxx
@@ -64,6 +64,7 @@ QueueRegistry::create_queue(const confmodel::Queue* config)
     throw QueueTypeUnknown(ERS_HERE, config->get_queue_type());
   }
 
+  queue->set_direct_callbacks_enabled(config->get_direct_callbacks_enabled());
   m_opmon_link->register_node(config->UID(), queue);
 
   return queue;

--- a/include/iomanager/queue/detail/QueueSenderModel.hxx
+++ b/include/iomanager/queue/detail/QueueSenderModel.hxx
@@ -29,6 +29,12 @@ QueueSenderModel<Datatype>::try_send(Datatype&& data, Sender::timeout_t timeout)
     return false;
   }
 
+  auto cb = m_queue->get_callback();
+  if (cb) {
+    cb(std::move(data));
+    return true;
+  }
+
   return m_queue->try_push(std::move(data), timeout);
 }
 
@@ -38,6 +44,12 @@ QueueSenderModel<Datatype>::send(Datatype&& data, Sender::timeout_t timeout) // 
 {
   if (m_queue == nullptr)
     throw ConnectionInstanceNotFound(ERS_HERE, this->id().uid);
+
+  auto cb = m_queue->get_callback();
+  if (cb) {
+    cb(std::move(data));
+    return;
+  }
 
   try {
     m_queue->push(std::move(data), timeout);

--- a/test/config/iomanager_test.data.xml
+++ b/test/config/iomanager_test.data.xml
@@ -63,7 +63,7 @@
 
 <oks-data>
 
-<info name="" type="" num-of-items="11" oks-format="data" oks-version="862f2957270" created-by="gjc" created-on="thinkpad" creation-time="20231110T143339" last-modified-by="eflumerf" last-modified-on="ironvirt9.mshome.net" last-modification-time="20241010T181349"/>
+<info name="" type="" num-of-items="12" oks-format="data" oks-version="862f2957270" created-by="gjc" created-on="thinkpad" creation-time="20231110T143339" last-modified-by="eflumerf" last-modified-on="ironvirt9.mshome.net" last-modification-time="20251119T221025"/>
 
 <include>
  <file path="schema/confmodel/dunedaq.schema.xml"/>
@@ -116,19 +116,30 @@
  <rel name="associated_service" class="Service" id="foo"/>
 </obj>
 
-<obj class="Queue" id="queue">
+<obj class="Queue" id="direct_queue">
  <attr name="data_type" type="string" val="data_t"/>
+ <attr name="capacity" type="u32" val="50"/>
  <attr name="send_timeout_ms" type="u32" val="10"/>
  <attr name="recv_timeout_ms" type="u32" val="10"/>
+ <attr name="direct_callbacks_enabled" type="bool" val="1"/>
+ <attr name="queue_type" type="enum" val="kFollySPSCQueue"/>
+</obj>
+
+<obj class="Queue" id="queue">
+ <attr name="data_type" type="string" val="data_t"/>
  <attr name="capacity" type="u32" val="50"/>
+ <attr name="send_timeout_ms" type="u32" val="10"/>
+ <attr name="recv_timeout_ms" type="u32" val="10"/>
+ <attr name="direct_callbacks_enabled" type="bool" val="0"/>
  <attr name="queue_type" type="enum" val="kFollySPSCQueue"/>
 </obj>
 
 <obj class="Queue" id="test">
  <attr name="data_type" type="string" val="data3_t"/>
+ <attr name="capacity" type="u32" val="50"/>
  <attr name="send_timeout_ms" type="u32" val="10"/>
  <attr name="recv_timeout_ms" type="u32" val="10"/>
- <attr name="capacity" type="u32" val="50"/>
+ <attr name="direct_callbacks_enabled" type="bool" val="0"/>
  <attr name="queue_type" type="enum" val="kFollySPSCQueue"/>
 </obj>
 

--- a/unittest/IOManager_test.cxx
+++ b/unittest/IOManager_test.cxx
@@ -668,6 +668,11 @@ BOOST_FIXTURE_TEST_CASE(DirectCallbackRegistration, ConfigurationTestFixture)
     recv_data = d;
   };
 
+  auto net_recvr = IOManager::get()->get_receiver<Data>(conn_id);
+  auto q_recvr = IOManager::get()->get_receiver<Data>(queue_id);
+  BOOST_REQUIRE(!net_recvr->direct_callbacks_supported());
+  BOOST_REQUIRE(q_recvr->direct_callbacks_supported());
+
   BOOST_REQUIRE_EXCEPTION(IOManager::get()->add_direct_callback<Data>(conn_id, direct_callback),
                           DirectCallbacksUnsupported,
                           [](DirectCallbacksUnsupported const&) { return true; });

--- a/unittest/IOManager_test.cxx
+++ b/unittest/IOManager_test.cxx
@@ -179,6 +179,7 @@ struct ConfigurationTestFixture
 
     conn_id = ConnectionId{ "network", "data_t" };
     queue_id = ConnectionId{ "queue", "data_t" };
+    dqueue_id = ConnectionId{ "direct_queue", "data_t" };
 
     pub1_id = ConnectionId{ "pub1", "data2_t" };
     pub2_id = ConnectionId{ "pub2", "data2_t" };
@@ -199,6 +200,7 @@ struct ConfigurationTestFixture
 
   ConnectionId conn_id;
   ConnectionId queue_id;
+  ConnectionId dqueue_id;
   ConnectionId pub1_id;
   ConnectionId pub2_id;
   ConnectionId pub3_id;
@@ -411,7 +413,7 @@ BOOST_FIXTURE_TEST_CASE(NotFound, ConfigurationTestFixture)
   auto ret = receiver->try_receive(std::chrono::milliseconds(10));
   BOOST_REQUIRE_EQUAL(ret.has_value(), false);
 
-  std::function<void(Data2&)> callback = [&](Data2&) { BOOST_REQUIRE(false); };
+  std::function<void(Data2&&)> callback = [&](Data2&&) { BOOST_REQUIRE(false); };
   IOManager::get()->add_callback<Data2>(bad_id, callback);
 
   usleep(1000000);
@@ -505,7 +507,7 @@ BOOST_FIXTURE_TEST_CASE(CallbackRegistration, ConfigurationTestFixture)
   Data recv_data;
   std::atomic<bool> has_received_data = false;
 
-  std::function<void(Data&)> callback = [&](Data& d) {
+  std::function<void(Data&&)> callback = [&](Data&& d) {
     has_received_data = true;
     recv_data = std::move(d);
   };
@@ -548,7 +550,7 @@ BOOST_FIXTURE_TEST_CASE(NonCopyableCallbackRegistration, ConfigurationTestFixtur
   NonCopyableData recv_data;
   std::atomic<bool> has_received_data = false;
 
-  std::function<void(NonCopyableData&)> callback = [&](NonCopyableData& d) {
+  std::function<void(NonCopyableData&&)> callback = [&](NonCopyableData&& d) {
     has_received_data = true;
     recv_data = std::move(d);
   };
@@ -591,7 +593,7 @@ BOOST_FIXTURE_TEST_CASE(NonSerializableCallbackRegistration, ConfigurationTestFi
   NonSerializableData recv_data;
   std::atomic<bool> has_received_data = false;
 
-  std::function<void(NonSerializableData&)> callback = [&](NonSerializableData& d) {
+  std::function<void(NonSerializableData&&)> callback = [&](NonSerializableData&& d) {
     has_received_data = true;
     recv_data = std::move(d);
   };
@@ -626,7 +628,7 @@ BOOST_FIXTURE_TEST_CASE(NonSerializableNonCopyableCallbackRegistration, Configur
   NonSerializableNonCopyable recv_data;
   std::atomic<bool> has_received_data = false;
 
-  std::function<void(NonSerializableNonCopyable&)> callback = [&](NonSerializableNonCopyable& d) {
+  std::function<void(NonSerializableNonCopyable&&)> callback = [&](NonSerializableNonCopyable&& d) {
     has_received_data = true;
     recv_data = std::move(d);
   };
@@ -655,10 +657,8 @@ BOOST_FIXTURE_TEST_CASE(NonSerializableNonCopyableCallbackRegistration, Configur
 
 BOOST_FIXTURE_TEST_CASE(DirectCallbackRegistration, ConfigurationTestFixture)
 {
-  auto net_sender = IOManager::get()->get_sender<Data>(conn_id);
-  auto q_sender = IOManager::get()->get_sender<Data>(queue_id);
+  auto q_sender = IOManager::get()->get_sender<Data>(dqueue_id);
 
-  Data sent_data_nw(56, 26.5, "test1");
   Data sent_data_q(57, 27.5, "test2");
   Data recv_data;
   std::atomic<bool> has_received_data = false;
@@ -668,15 +668,10 @@ BOOST_FIXTURE_TEST_CASE(DirectCallbackRegistration, ConfigurationTestFixture)
     recv_data = d;
   };
 
-  auto net_recvr = IOManager::get()->get_receiver<Data>(conn_id);
-  auto q_recvr = IOManager::get()->get_receiver<Data>(queue_id);
-  BOOST_REQUIRE(!net_recvr->direct_callbacks_supported());
-  BOOST_REQUIRE(q_recvr->direct_callbacks_supported());
+  auto q_recvr = IOManager::get()->get_receiver<Data>(dqueue_id);
+  BOOST_REQUIRE(q_recvr->direct_callbacks_enabled());
 
-  BOOST_REQUIRE_EXCEPTION(IOManager::get()->add_direct_callback<Data>(conn_id, direct_callback),
-                          DirectCallbacksUnsupported,
-                          [](DirectCallbacksUnsupported const&) { return true; });
-  IOManager::get()->add_direct_callback<Data>(queue_id, direct_callback);
+  IOManager::get()->add_callback<Data>(dqueue_id, direct_callback);
 
   has_received_data = false;
   q_sender->send(std::move(sent_data_q), std::chrono::milliseconds(10));
@@ -687,8 +682,7 @@ BOOST_FIXTURE_TEST_CASE(DirectCallbackRegistration, ConfigurationTestFixture)
   BOOST_CHECK_EQUAL(recv_data.d2, 27.5);
   BOOST_CHECK_EQUAL(recv_data.d3, "test2");
 
-  IOManager::get()->remove_callback<Data>(conn_id);
-  IOManager::get()->remove_callback<Data>(queue_id);
+  IOManager::get()->remove_callback<Data>(dqueue_id);
 }
 
 BOOST_FIXTURE_TEST_CASE(GetDatatype, ConfigurationTestFixture)

--- a/unittest/IOManager_test.cxx
+++ b/unittest/IOManager_test.cxx
@@ -653,6 +653,39 @@ BOOST_FIXTURE_TEST_CASE(NonSerializableNonCopyableCallbackRegistration, Configur
   IOManager::get()->remove_callback<NonSerializableNonCopyable>(queue_id);
 }
 
+BOOST_FIXTURE_TEST_CASE(DirectCallbackRegistration, ConfigurationTestFixture)
+{
+  auto net_sender = IOManager::get()->get_sender<Data>(conn_id);
+  auto q_sender = IOManager::get()->get_sender<Data>(queue_id);
+
+  Data sent_data_nw(56, 26.5, "test1");
+  Data sent_data_q(57, 27.5, "test2");
+  Data recv_data;
+  std::atomic<bool> has_received_data = false;
+
+  std::function<void(Data&&)> direct_callback = [&](Data&& d) {
+    has_received_data = true;
+    recv_data = d;
+  };
+
+  BOOST_REQUIRE_EXCEPTION(IOManager::get()->add_direct_callback<Data>(conn_id, direct_callback),
+                          DirectCallbacksUnsupported,
+                          [](DirectCallbacksUnsupported const&) { return true; });
+  IOManager::get()->add_direct_callback<Data>(queue_id, direct_callback);
+
+  has_received_data = false;
+  q_sender->send(std::move(sent_data_q), std::chrono::milliseconds(10));
+  // Synchronous
+  BOOST_REQUIRE(has_received_data);
+
+  BOOST_CHECK_EQUAL(recv_data.d1, 57);
+  BOOST_CHECK_EQUAL(recv_data.d2, 27.5);
+  BOOST_CHECK_EQUAL(recv_data.d3, "test2");
+
+  IOManager::get()->remove_callback<Data>(conn_id);
+  IOManager::get()->remove_callback<Data>(queue_id);
+}
+
 BOOST_FIXTURE_TEST_CASE(GetDatatype, ConfigurationTestFixture)
 {
   auto networkDataTypes = IOManager::get()->get_datatypes("network");


### PR DESCRIPTION
# Description

This PR enables "direct" queue callbacks, similar to #122, but in this version, the direct callbacks replace the regular Queue callbacks. This behavior is configured via the Queue configuration. To accomplish this change, the callback API signature had to change, so this PR will require a number of changes in other repositories (in addition to the additional configuration parameters in Queue and QueueDescriptor).


## Type of change

- [x] Breaking change (whatever its nature)

## Testing checklist

- [x] Unit tests pass (e.g. `dbt-build --unittest`)
- [x] Minimal system quicktest passes (`pytest -s minimal_system_quick_test.py`)
- [x] Full set of integration tests pass (`daqsystemtest_integtest_bundle.sh`)

_Comments here on the testing_
To properly test this change, selected queues should have "direct_callbacks_enabled" enabled and the test suite run again.

## Further checks

- [x] Code is commented where needed, particularly in hard-to-understand areas
- [ ] Code style is correct (`dbt-build --lint`, and/or see https://dune-daq-sw.readthedocs.io/en/latest/packages/styleguide/)
- [x] If applicable, new tests have been added or an issue has been opened to tackle that in the future.
  (Indicate issue here: # (issue))

