### PR TITLE
Add get_callback method needed for DataMoveCallbackRegistry API

### DIFF
--- a/include/iomanager/IOManager.hpp
+++ b/include/iomanager/IOManager.hpp
@@ -87,8 +87,18 @@ public:
 
   template<typename Datatype>
   void remove_callback(std::string const& uid);
+
   template<typename Datatype>
   void remove_callback(std::string const& uid, std::string const& tag);
+
+  template<typename Datatype>
+  std::function<void(Datatype&&)> get_callback(ConnectionId const& id);
+
+  template<typename Datatype>
+  std::function<void(Datatype&&)> get_callback(std::string const& uid);
+
+  template<typename Datatype>
+  std::function<void(Datatype&&)> get_callback(std::string const& uid, std::string const& tag);
 
   std::set<std::string> get_datatypes(std::string const& uid);
 

--- a/include/iomanager/Receiver.hpp
+++ b/include/iomanager/Receiver.hpp
@@ -54,6 +54,7 @@ public:
   virtual Datatype receive(Receiver::timeout_t timeout) = 0;
   virtual std::optional<Datatype> try_receive(Receiver::timeout_t timeout) = 0;
   virtual void add_callback(std::function<void(Datatype&&)> callback) = 0;
+  virtual std::function<void(Datatype&&)> get_callback() = 0;
   virtual bool direct_callbacks_enabled() { return false; }
   virtual void remove_callback() = 0;
   virtual void subscribe(std::string topic) = 0;

--- a/include/iomanager/detail/IOManager.hxx
+++ b/include/iomanager/detail/IOManager.hxx
@@ -157,6 +157,30 @@ IOManager::remove_callback(std::string const& uid, std::string const& tag)
   receiver->remove_callback();
 }
 
+template<typename Datatype>
+inline std::function<void(Datatype&&)>
+IOManager::get_callback(ConnectionId const& id)
+{
+  auto receiver = get_receiver<Datatype>(id);
+  return receiver->get_callback();
+}
+
+template<typename Datatype>
+inline std::function<void(Datatype&&)>
+IOManager::get_callback(std::string const& uid)
+{
+  auto receiver = get_receiver<Datatype>(uid);
+  return receiver->get_callback();
+}
+
+template<typename Datatype>
+inline std::function<void(Datatype&&)>
+IOManager::get_callback(std::string const& uid, std::string const& tag)
+{
+  auto receiver = get_receiver<Datatype>(uid, tag);
+  return receiver->get_callback();
+}
+
 } // namespace iomanager
 
 // Helper functions

--- a/include/iomanager/network/NetworkReceiverModel.hpp
+++ b/include/iomanager/network/NetworkReceiverModel.hpp
@@ -37,6 +37,7 @@ public:
   void add_callback(std::function<void(Datatype&&)> callback) override { add_callback_impl<Datatype>(callback); }
 
   void remove_callback() override;
+  std::function<void(Datatype&&)> get_callback() override;
 
   void subscribe(std::string topic) override;
   void unsubscribe(std::string topic) override;

--- a/include/iomanager/network/detail/NetworkReceiverModel.hxx
+++ b/include/iomanager/network/detail/NetworkReceiverModel.hxx
@@ -65,6 +65,13 @@ NetworkReceiverModel<Datatype>::remove_callback()
 }
 
 template<typename Datatype>
+inline std::function<void(Datatype&&)>
+NetworkReceiverModel<Datatype>::get_callback()
+{
+  return m_callback;
+}
+
+template<typename Datatype>
 inline void
 NetworkReceiverModel<Datatype>::subscribe(std::string topic)
 {

--- a/include/iomanager/queue/QueueReceiverModel.hpp
+++ b/include/iomanager/queue/QueueReceiverModel.hpp
@@ -43,6 +43,8 @@ public:
 
   void remove_callback() override;
 
+  std::function<void(Datatype&&)> get_callback() override;
+
   // Topics are not used for Queues
   void subscribe(std::string) override {}
   void unsubscribe(std::string) override {}

--- a/include/iomanager/queue/detail/QueueReceiverModel.hxx
+++ b/include/iomanager/queue/detail/QueueReceiverModel.hxx
@@ -140,4 +140,15 @@ QueueReceiverModel<Datatype>::remove_callback()
   // remove function.
 }
 
+template<typename Datatype>
+inline std::function<void(Datatype&&)>
+QueueReceiverModel<Datatype>::get_callback()
+{
+  if (m_queue != nullptr && m_queue->get_callback()) {
+    return m_queue->get_callback();
+  }
+
+  return m_callback;
+}
+
 } // namespace dunedaq::iomanager


### PR DESCRIPTION
# Description

See DUNE-DAQ/datahandlinglibs#119 for details. Requires DUNE-DAQ/iomanager#125


## Type of change

- [x] Breaking change (whatever its nature)

## Testing checklist

- [x] Unit tests pass (e.g. `dbt-build --unittest`)
- [x] Minimal system quicktest passes (`pytest -s minimal_system_quick_test.py`)
- [x] Full set of integration tests pass (`daqsystemtest_integtest_bundle.sh`)
- [ ] Python tests pass if applicable (e.g. `python -m pytest`)
- [ ] Pre-commit hooks run successfully if applicable (e.g. `pre-commit run --all-files`)

_Comments here on the testing_

## Further checks

- [ ] Code is commented where needed, particularly in hard-to-understand areas
- [ ] Code style is correct (`dbt-build --lint`, and/or see https://dune-daq-sw.readthedocs.io/en/latest/packages/styleguide/)
- [ ] If applicable, new tests have been added or an issue has been opened to tackle that in the future.
  (Indicate issue here: # (issue))

