### PR TITLE
Add a data_pending() method to iomanager::Receiver. 

### DIFF
--- a/include/iomanager/Receiver.hpp
+++ b/include/iomanager/Receiver.hpp
@@ -53,6 +53,7 @@ public:
   }
   virtual Datatype receive(Receiver::timeout_t timeout) = 0;
   virtual std::optional<Datatype> try_receive(Receiver::timeout_t timeout) = 0;
+  virtual bool data_pending() = 0;
   virtual void add_callback(std::function<void(Datatype&)> callback) = 0;
   virtual void remove_callback() = 0;
   virtual void subscribe(std::string topic) = 0;

--- a/include/iomanager/network/NetworkReceiverModel.hpp
+++ b/include/iomanager/network/NetworkReceiverModel.hpp
@@ -34,6 +34,9 @@ public:
   {
     return try_read_network<Datatype>(timeout);
   }
+
+  bool data_pending() override { return m_network_receiver_ptr && m_network_receiver_ptr->data_pending(); }
+
   void add_callback(std::function<void(Datatype&)> callback) override { add_callback_impl<Datatype>(callback); }
 
   void remove_callback() override;

--- a/include/iomanager/queue/QueueReceiverModel.hpp
+++ b/include/iomanager/queue/QueueReceiverModel.hpp
@@ -37,6 +37,8 @@ public:
 
   std::optional<Datatype> try_receive(Receiver::timeout_t timeout) override;
 
+  bool data_pending() override { return m_queue && m_queue->can_pop(); }
+
   void add_callback(std::function<void(Datatype&)> callback) override;
 
   void remove_callback() override;


### PR DESCRIPTION
Implement via ipm::Receiver::data_pending() and iomanager::Queue::can_pop()

# Description

See issue #128 for details

Adds a method so that a DAQModule can ask an iomanager Receiver object if there is any data pending receive (for non-callback-based Receivers).

## Type of change

- [x] New feature or enhancement (non-breaking change which adds functionality)

## Testing checklist

- [x] Unit tests pass (e.g. `dbt-build --unittest`)
- [x] Minimal system quicktest passes (`pytest -s minimal_system_quick_test.py`)
- [x] Full set of integration tests pass (`daqsystemtest_integtest_bundle.sh`)

This change should be tested together with DUNE-DAQ/ipm#117.  N.B. that we should also clone `dfmodules`, `fdreadoutlibs`, `fdreadoutmodules`, `trigger`, and `hsilibs` into our software areas when testing these changes.

## Further checks

- [x] Code is commented where needed, particularly in hard-to-understand areas
- [x] Code style is correct (`dbt-build --lint`, and/or see https://dune-daq-sw.readthedocs.io/en/latest/packages/styleguide/)

