### PR TITLE
Configure connect-type endpoints using a given virtual host name to bind to specific IPs

### DIFF
--- a/include/iomanager/IOManager.hpp
+++ b/include/iomanager/IOManager.hpp
@@ -50,7 +50,7 @@ public:
   IOManager(IOManager&&) = delete;                 ///< IOManager is not move-constructible
   IOManager& operator=(IOManager&&) = delete;      ///< IOManager is not move-assignable
 
-  void configure(std::string session,
+  void configure(std::string session, std::string vhost_name,
                  std::vector<const confmodel::Queue*> queues,
                  std::vector<const confmodel::NetworkConnection*> connections,
                  const confmodel::ConnectivityService* connection_service,

--- a/include/iomanager/detail/IOManager.hxx
+++ b/include/iomanager/detail/IOManager.hxx
@@ -70,8 +70,8 @@ IOManager::get_receiver(ConnectionId id)
       TLOG() << "Creating QueueReceiverModel for uid " << id.uid << ", datatype " << id.data_type;
       m_receivers[id] = std::make_shared<QueueReceiverModel<Datatype>>(id);
     } else {
-      TLOG() << "Creating NetworkReceiverModel for uid " << id.uid << ", datatype " << id.data_type
-                        << " in session " << id.session;
+      TLOG() << "Creating NetworkReceiverModel for uid " << id.uid << ", datatype " << id.data_type << " in session "
+             << id.session;
       m_receivers[id] = std::make_shared<NetworkReceiverModel<Datatype>>(id);
     }
   }
@@ -110,8 +110,8 @@ IOManager::get_sender(ConnectionId id)
       TLOG() << "Creating QueueSenderModel for uid " << id.uid << ", datatype " << id.data_type;
       m_senders[id] = std::make_shared<QueueSenderModel<Datatype>>(id);
     } else {
-      TLOG() << "Creating NetworkSenderModel for uid " << id.uid << ", datatype " << id.data_type
-                        << " in session " << id.session;
+      TLOG() << "Creating NetworkSenderModel for uid " << id.uid << ", datatype " << id.data_type << " in session "
+             << id.session;
       m_senders[id] = std::make_shared<NetworkSenderModel<Datatype>>(id);
     }
   }

--- a/include/iomanager/network/NetworkManager.hpp
+++ b/include/iomanager/network/NetworkManager.hpp
@@ -43,6 +43,7 @@ public:
   ~NetworkManager() { reset(); }
 
   void configure(const std::string& session_name,
+                 const std::string& vhost_name,
                  const std::vector<const confmodel::NetworkConnection*>& connections,
                  const confmodel::ConnectivityService* conn_svc,
                  dunedaq::opmonlib::OpMonManager&);
@@ -78,6 +79,7 @@ private:
   std::vector<std::string> get_pubsub_connection_strings(std::vector<ConnectionInfo> const& connections);
   void update_subscribers();
 
+  std::string m_vhost_name{ "" };
   std::unordered_map<ConnectionId, const confmodel::NetworkConnection*> m_preconfigured_connections;
   std::unordered_map<ConnectionId, std::shared_ptr<ipm::Receiver>> m_receiver_plugins;
   std::unordered_map<ConnectionId, std::shared_ptr<ipm::Sender>> m_sender_plugins;

--- a/include/iomanager/network/detail/NetworkSenderModel.hxx
+++ b/include/iomanager/network/detail/NetworkSenderModel.hxx
@@ -19,12 +19,11 @@ template<typename Datatype>
 inline NetworkSenderModel<Datatype>::NetworkSenderModel(ConnectionId const& conn_id)
   : SenderConcept<Datatype>(conn_id)
 {
-  TLOG() << "NetworkSenderModel created with DT! Addr: " << static_cast<void*>(this)
-                             << ", uid=" << conn_id.uid << ", data_type=" << conn_id.data_type;
+  TLOG() << "NetworkSenderModel created with DT! Addr: " << static_cast<void*>(this) << ", uid=" << conn_id.uid
+         << ", data_type=" << conn_id.data_type;
   get_sender(std::chrono::milliseconds(1000));
   if (m_network_sender_ptr == nullptr) {
-    TLOG() << "Initial connection attempt failed for uid=" << conn_id.uid
-                               << ", data_type=" << conn_id.data_type;
+    TLOG() << "Initial connection attempt failed for uid=" << conn_id.uid << ", data_type=" << conn_id.data_type;
   }
 }
 

--- a/include/iomanager/queue/detail/QueueReceiverModel.hxx
+++ b/include/iomanager/queue/detail/QueueReceiverModel.hxx
@@ -95,8 +95,7 @@ QueueReceiverModel<Datatype>::add_callback(std::function<void(Datatype&)> callba
     bool ret = true;
     while (!token.stop_requested() || ret) {
       // TLOG() << "Take data from q then invoke callback...";
-      ret = m_queue->try_pop(dt, token.stop_requested() ? std::chrono::milliseconds(0) 
-          : std::chrono::milliseconds(1));
+      ret = m_queue->try_pop(dt, token.stop_requested() ? std::chrono::milliseconds(0) : std::chrono::milliseconds(1));
       if (ret) {
         m_callback(dt);
       }

--- a/src/IOManager.cpp
+++ b/src/IOManager.cpp
@@ -19,6 +19,7 @@ std::shared_ptr<IOManager> IOManager::s_instance = nullptr;
 
 void
 IOManager::configure(std::string session,
+                     std::string vhost_name,
                      std::vector<const confmodel::Queue*> queues,
                      std::vector<const confmodel::NetworkConnection*> connections,
                      const confmodel::ConnectivityService* connection_service,
@@ -27,7 +28,7 @@ IOManager::configure(std::string session,
   m_session = session;
 
   QueueRegistry::get().configure(queues, opmgr);
-  NetworkManager::get().configure(session, connections, connection_service, opmgr);
+  NetworkManager::get().configure(session, vhost_name, connections, connection_service, opmgr);
 }
 
 void

--- a/src/network/NetworkManager.cpp
+++ b/src/network/NetworkManager.cpp
@@ -39,6 +39,7 @@ NetworkManager::get()
 
 void
 NetworkManager::configure(const std::string& session_name,
+                          const std::string& vhost_name,
                           const std::vector<const confmodel::NetworkConnection*>& connections,
                           const confmodel::ConnectivityService* conn_svc,
                           dunedaq::opmonlib::OpMonManager& opmgr)
@@ -46,6 +47,8 @@ NetworkManager::configure(const std::string& session_name,
   if (!m_preconfigured_connections.empty()) {
     throw AlreadyConfigured(ERS_HERE);
   }
+
+  m_vhost_name = vhost_name;
 
   for (auto& connection : connections) {
     auto name = connection->UID();
@@ -373,11 +376,13 @@ NetworkManager::create_sender(ConnectionInfo connection)
   TLOG_DEBUG(11) << "Connecting sender plugin to " << connection.uri;
   ipm::Sender::ConnectionInfo conn_info(connection.uid, connection.uri, connection.capacity);
 
-  TLOG_DEBUG(11) << "Determining if specific send endpoints are needed for connection URI " << connection.uri;
   utilities::ZmqUri oldUri(connection.uri);
-  auto endpoints = utilities::get_ips_matching_network(oldUri.host);
-  if (endpoints.size() > 1) {
-    conn_info.send_endpoints = endpoints;
+  if (m_vhost_name != "") {
+    TLOG_DEBUG(11) << "Getting IP of VirtualHost " << m_vhost_name << " for configuring sender to " << connection.uri;
+    auto endpoints = utilities::get_hostname_ips(m_vhost_name);
+    if (endpoints.size() > 0) {
+      conn_info.send_endpoint = endpoints[0];
+    }
   }
 
   auto newCs = plugin->connect_for_sends(conn_info);

--- a/src/network/NetworkManager.cpp
+++ b/src/network/NetworkManager.cpp
@@ -371,15 +371,19 @@ NetworkManager::create_sender(ConnectionInfo connection)
   TLOG_DEBUG(11) << "Creating sender plugin of type " << plugin_type;
   auto plugin = dunedaq::ipm::make_ipm_sender(plugin_type);
   TLOG_DEBUG(11) << "Connecting sender plugin to " << connection.uri;
-  auto newCs =
-    plugin->connect_for_sends({ { "connection_string", connection.uri }, { "capacity", connection.capacity } });
+  utilities::ZmqUri oldUri(connection.uri);
+  auto endpoints = utilities::get_ips_matching_network(oldUri.host);
+  nlohmann::json connection_json = { { "connection_string", connection.uri }, { "capacity", connection.capacity } };
+  if (endpoints.size() > 1) {
+    connection_json["send_endpoints"] = endpoints;
+  }
+  auto newCs = plugin->connect_for_sends(connection_json);
   TLOG_DEBUG(11) << "Sender Plugin connected, reports URI " << newCs;
 
   // Replace with resolved if there are wildcards (host and/or port)
   if (connection.uri.find("*") != std::string::npos || connection.uri.find("0.0.0.0") != std::string::npos) {
     TLOG_DEBUG(13) << "Wildcard found in connection URI " << connection.uri << ", adjusting before publish";
     utilities::ZmqUri newUri(newCs);
-    utilities::ZmqUri oldUri(connection.uri);
 
     if (oldUri.port == "*")
       oldUri.port = newUri.port;

--- a/unittest/IOManager_test.cxx
+++ b/unittest/IOManager_test.cxx
@@ -188,7 +188,8 @@ struct ConfigurationTestFixture
     sub2_id = ConnectionId{ "pub2", "data2_t" };
     sub3_id = ConnectionId{ "pub.*", "data3_t" };
 
-    IOManager::get()->configure("IOManager_t", queues, connections, nullptr, opmgr); // Not using connectivity service
+    IOManager::get()->configure(
+      "IOManager_t", "localhost", queues, connections, nullptr, opmgr); // Not using connectivity service
   }
   ~ConfigurationTestFixture() { IOManager::get()->reset(); }
 

--- a/unittest/NetworkManager_test.cxx
+++ b/unittest/NetworkManager_test.cxx
@@ -44,7 +44,7 @@ struct NetworkManagerTestFixture
     pubSubConnId3.data_type = "String";
 
     dunedaq::opmonlib::TestOpMonManager opmgr;
-    NetworkManager::get().configure("NetworkManager_t", connections, nullptr, opmgr); // Not using ConfigClient
+    NetworkManager::get().configure("NetworkManager_t", "localhost", connections, nullptr, opmgr); // Not using ConfigClient
   }
   ~NetworkManagerTestFixture() { NetworkManager::get().reset(); }
 
@@ -121,13 +121,13 @@ BOOST_FIXTURE_TEST_CASE(FakeConfigure, NetworkManagerTestFixture)
                           [](ConnectionNotFound const&) { return true; });
 
   dunedaq::opmonlib::TestOpMonManager opmgr;
-  BOOST_REQUIRE_EXCEPTION(NetworkManager::get().configure("NetworkManager_t", connections, nullptr, opmgr),
+  BOOST_REQUIRE_EXCEPTION(NetworkManager::get().configure("NetworkManager_t", "localhost", connections, nullptr, opmgr),
                           AlreadyConfigured,
                           [&](AlreadyConfigured const&) { return true; });
 
   NetworkManager::get().reset();
 
-  NetworkManager::get().configure("NetworkManager_t", connections, nullptr, opmgr);
+  NetworkManager::get().configure("NetworkManager_t", "localhost", connections, nullptr, opmgr);
 }
 
 BOOST_FIXTURE_TEST_CASE(GetDatatypes, NetworkManagerTestFixture)

--- a/unittest/performance_test.cxx
+++ b/unittest/performance_test.cxx
@@ -51,7 +51,8 @@ struct ConfigurationTestFixture
     confdb->get<dunedaq::confmodel::Queue>(queues);
     confdb->get<dunedaq::confmodel::NetworkConnection>(connections);
 
-    IOManager::get()->configure("performance_t", queues, connections, nullptr, opmgr); // Not using connectivity service
+    IOManager::get()->configure(
+      "performance_t", "localhost", queues, connections, nullptr, opmgr); // Not using connectivity service
   }
   ~ConfigurationTestFixture() { IOManager::get()->reset(); }
 


### PR DESCRIPTION
# Description

Related: https://github.com/DUNE-DAQ/ipm/pull/119

Using the changes from the IPM PR, set up each connect-type connection to use all local interfaces that are on the same network. This is an interim solution while we think about the appropriate way to configure this behavior (e.g. to allow senders to only use the NIC that is on the same NUMA node).


## Type of change

- [x] New feature or enhancement (non-breaking change which adds functionality)

## Testing checklist

- [x] Unit tests pass (e.g. `dbt-build --unittest`)
- [x] Minimal system quicktest passes (`pytest -s minimal_system_quick_test.py`)
- [x] Full set of integration tests pass (`dunedaq_integtest_bundle.sh`)
